### PR TITLE
fixed #18 A server must not mask any frames that it sends to the client.

### DIFF
--- a/server.js
+++ b/server.js
@@ -130,7 +130,7 @@ function Bridge (wsConnection) {
     // add port
     buffy.writeUInt16LE(rinfo.port, 4)
 
-    self.websocket.send(buffy, { binary: true, mask: true })
+    self.websocket.send(buffy, { binary: true })
   })
   this.udp.on('close', function (message) {
     if (self.websocket) {


### PR DESCRIPTION
Removed the mask parameter in the from sim to client function.