### PR TITLE
Load saved grids and avatars only once

### DIFF
--- a/src/actions/viewerAccount.js
+++ b/src/actions/viewerAccount.js
@@ -56,9 +56,13 @@ export function saveAvatar (name, grid) {
 
 export function loadSavedAvatars () {
   return (dispatch, getState, {hoodie}) => {
-    if (!getState().account.getIn(['viewerAccount', 'loggedIn'])) {
+    const account = getState().account
+
+    if (!account.getIn(['viewerAccount', 'loggedIn'])) {
       return Promise.reject(new Error('Not signed in to Viewer!'))
     }
+
+    if (account.get('savedAvatarsLoaded')) return Promise.resolve()
 
     const avatarsStore = hoodie.store.withIdPrefix('avatars/')
 
@@ -121,9 +125,13 @@ export function saveGrid (name, loginURL) {
 
 export function loadSavedGrids () {
   return (dispatch, getState, {hoodie}) => {
-    if (!getState().account.getIn(['viewerAccount', 'loggedIn'])) {
+    const account = getState().account
+
+    if (!account.getIn(['viewerAccount', 'loggedIn'])) {
       return Promise.reject(new Error('Not signed in to Viewer!'))
     }
+
+    if (account.get('savedGridsLoaded')) return Promise.resolve()
 
     const gridsStore = hoodie.store.withIdPrefix('grids/')
 

--- a/src/actions/viewerAccount.js
+++ b/src/actions/viewerAccount.js
@@ -55,14 +55,14 @@ export function saveAvatar (name, grid) {
 }
 
 export function loadSavedAvatars () {
-  return (dispatch, getState, {hoodie}) => {
+  return async (dispatch, getState, {hoodie}) => {
     const account = getState().account
 
     if (!account.getIn(['viewerAccount', 'loggedIn'])) {
-      return Promise.reject(new Error('Not signed in to Viewer!'))
+      throw new Error('Not signed in to Viewer!')
     }
 
-    if (account.get('savedAvatarsLoaded')) return Promise.resolve()
+    if (account.get('savedAvatarsLoaded')) return
 
     const avatarsStore = hoodie.store.withIdPrefix('avatars/')
 
@@ -70,11 +70,10 @@ export function loadSavedAvatars () {
       dispatch(avatarsDidChange(eventName, doc))
     })
 
-    return avatarsStore.findAll().then(avatars => {
-      dispatch({
-        type: 'AvatarsLoaded',
-        avatars
-      })
+    const avatars = await avatarsStore.findAll()
+    dispatch({
+      type: 'AvatarsLoaded',
+      avatars
     })
   }
 }
@@ -124,14 +123,14 @@ export function saveGrid (name, loginURL) {
 }
 
 export function loadSavedGrids () {
-  return (dispatch, getState, {hoodie}) => {
+  return async (dispatch, getState, {hoodie}) => {
     const account = getState().account
 
     if (!account.getIn(['viewerAccount', 'loggedIn'])) {
-      return Promise.reject(new Error('Not signed in to Viewer!'))
+      throw new Error('Not signed in to Viewer!')
     }
 
-    if (account.get('savedGridsLoaded')) return Promise.resolve()
+    if (account.get('savedGridsLoaded')) return
 
     const gridsStore = hoodie.store.withIdPrefix('grids/')
 
@@ -139,11 +138,10 @@ export function loadSavedGrids () {
       dispatch(gridsDidChange(change, doc))
     })
 
-    return gridsStore.findAll().then(grids => {
-      dispatch({
-        type: 'GridsLoaded',
-        grids
-      })
+    const grids = await gridsStore.findAll()
+    dispatch({
+      type: 'GridsLoaded',
+      grids
     })
   }
 }
@@ -171,34 +169,33 @@ function gridsDidChange (type, grid) {
 }
 
 export function isSignedIn () {
-  return (dispatch, getState, {hoodie}) => {
-    return hoodie.account.get(['session', 'username']).then(properties => {
-      const isLoggedIn = properties.session != null
-      const action = didSignIn(isLoggedIn, properties != null ? properties.username : undefined)
-      dispatch(action)
-      return isLoggedIn
-    })
+  return async (dispatch, getState, {hoodie}) => {
+    const properties = await hoodie.account.get(['session', 'username'])
+    const isLoggedIn = properties.session != null
+    const action = didSignIn(isLoggedIn, properties != null ? properties.username : undefined)
+    dispatch(action)
+    return isLoggedIn
   }
 }
 
 export function signIn (username, password) {
-  return (dispatch, getState, {hoodie}) => {
+  return async (dispatch, getState, {hoodie}) => {
     dispatch(closePopup())
-    return hoodie.account.signIn({username, password}).then(accountProperties => {
+    try {
+      const accountProperties = await hoodie.account.signIn({username, password})
       dispatch(didSignIn(true, accountProperties.username))
-    }).catch(err => {
+    } catch (err) {
       dispatch(didSignIn(false))
       console.error(err)
-    })
+    }
   }
 }
 
 export function signUp (username, password) {
-  return (dispatch, getState, {hoodie}) => {
+  return async (dispatch, getState, {hoodie}) => {
     dispatch(closePopup())
-    return hoodie.account.signUp({username, password}).then(accountProperties => {
-      dispatch(signIn(username, password))
-    })
+    await hoodie.account.signUp({username, password})
+    dispatch(signIn(username, password))
   }
 }
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -50,9 +50,9 @@ class App extends React.Component {
     })
   }
 
-  _loadAvatars () {
-    this.props.loadSavedGrids()
-      .then(() => this.props.loadSavedAvatars())
+  async _loadAvatars () {
+    await this.props.loadSavedGrids()
+    await this.props.loadSavedAvatars()
   }
 
   getPopup () {

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -13,6 +13,7 @@ function getDefault () {
       signInPopup: ''
     },
     savedAvatars: [],
+    savedAvatarsLoaded: false,
     savedGrids: [
       {
         name: 'Second Life',
@@ -26,7 +27,8 @@ function getDefault () {
         name: 'OS Grid',
         loginURL: 'http://login.osgrid.org/'
       }
-    ]
+    ],
+    savedGridsLoaded: false
   }
   return Immutable.fromJS(defaultData)
 }
@@ -79,7 +81,10 @@ export default function accountReducer (state = getDefault(), action) {
 
     case 'AvatarsLoaded':
       const savedAvatars = Immutable.fromJS(action.avatars)
-      return state.set('savedAvatars', savedAvatars)
+      return state.merge({
+        savedAvatars,
+        savedAvatarsLoaded: true
+      })
 
     case 'SavedAvatarUpdated':
       return state.set('savedAvatars', state.get('savedAvatars').map(avatar => {
@@ -97,7 +102,10 @@ export default function accountReducer (state = getDefault(), action) {
 
     case 'GridsLoaded':
       const loadedGrids = Immutable.fromJS(action.grids)
-      return state.set('savedGrids', state.get('savedGrids').concat(loadedGrids))
+      return state.merge({
+        savedGrids: state.get('savedGrids').concat(loadedGrids),
+        savedGridsLoaded: true
+      })
 
     case 'SavedGridDidChanged':
       return state.set('savedGrids', state.get('savedGrids').map(grid => {


### PR DESCRIPTION
This is for development.
Every time a change is made and saved, the UI will be reloaded. Which will load saved avatars and grids. Resulting in a memory leak.