### PR TITLE
UDP max acks

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@hoodie/client": "^10.1.1",
     "concurrently": "^3.5.1",
+    "double-ended-queue": "^2.1.0-0",
     "immutable": "^3.8.2",
     "markdown-chalk": "^1.4.0",
     "pouchdb": "^6.3.4",

--- a/src/network/circuit.js
+++ b/src/network/circuit.js
@@ -231,6 +231,7 @@ export default class Circuit extends events.EventEmitter {
   // Sends all acks after 100ms
   _sendAcks () {
     const acks = []
+    const toDelete = []
     for (const [sequenceNumber, timesSend] of this.simAcks) {
       acks.push({
         ID: sequenceNumber
@@ -239,9 +240,13 @@ export default class Circuit extends events.EventEmitter {
       if (timesSend === 0) {
         this.simAcks.set(sequenceNumber, timesSend + 1)
       } else {
-        this.simAcks.delete(sequenceNumber)
+        toDelete.push(sequenceNumber)
       }
     }
+
+    toDelete.forEach(sequenceNumber => {
+      this.simAcks.delete(sequenceNumber)
+    })
 
     this.send('PacketAck', {
       Packets: acks

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -203,7 +203,7 @@ test('circuit should send after 100ms a PacketAck', () => {
       } catch (err) {
         reject(err)
       }
-    }, 150)
+    }, 100)
   })
 })
 

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -238,6 +238,7 @@ describe('sending only 255 or less acks at the end of a package', () => {
   let sendAcks = []
 
   test('circuit only sends less then 256 Acks', () => {
+    circuit.simAcks = []
     for (let i = 0; i < 300; ++i) {
       const msg = createTestMessage(true, false, false)
       circuit.websocket.onmessage({data: msg})
@@ -260,7 +261,7 @@ describe('sending only 255 or less acks at the end of a package', () => {
       offset -= 4
       sendAcks.push(last.readUInt32LE(offset))
     }
-    sendAcks.sort()
+    sendAcks.sort((a, b) => a - b)
 
     const correctAcks = sendAcks.every((value, index, all) => index === 0
       ? true
@@ -293,7 +294,7 @@ describe('sending only 255 or less acks at the end of a package', () => {
     })
 
     test('not jet send acks are send first', () => {
-      const notJetSend = newAcks.filter(ack => !sendAcks.includes(ack)).sort()
+      const notJetSend = newAcks.filter(ack => !sendAcks.includes(ack)).sort((a, b) => a - b)
       expect(notJetSend.length).toBe(45)
 
       const correctAcks = notJetSend.every((value, index, all) => index === 0
@@ -304,7 +305,7 @@ describe('sending only 255 or less acks at the end of a package', () => {
     })
 
     test('old Acks are the oldest', () => {
-      const oldestAcks = newAcks.filter(ack => sendAcks.includes(ack)).sort()
+      const oldestAcks = newAcks.filter(ack => sendAcks.includes(ack)).sort((a, b) => a - b)
       expect(oldestAcks.length).toBe(210)
 
       oldestAcks.forEach((ack, index) => {

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -183,32 +183,44 @@ test('send ack at end of package', () => {
   ])
 })
 
-test('circuit should send after 100ms a PacketAck', done => {
-  setTimeout(() => {
-    // could be CompletePingCheck
-    const ackMessage1 = circuit.websocket.sendMessages[circuit.websocket.sendMessages.length - 2]
-    const ackMessage2 = circuit.websocket.sendMessages[circuit.websocket.sendMessages.length - 1]
-    const parsedAckMessageA = parseBody(ackMessage1.slice(12))
-    const parsedAckMessageB = parseBody(ackMessage2.slice(12))
-    const parsedAckMessage = parsedAckMessageA.name === 'PacketAck'
-      ? parsedAckMessageA
-      : parsedAckMessageB
+test('circuit should send after 100ms a PacketAck', () => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      // could be CompletePingCheck
+      const ackMessage1 = circuit.websocket.sendMessages[circuit.websocket.sendMessages.length - 2]
+      const ackMessage2 = circuit.websocket.sendMessages[circuit.websocket.sendMessages.length - 1]
+      const parsedAckMessageA = parseBody(ackMessage1.slice(12))
+      const parsedAckMessageB = parseBody(ackMessage2.slice(12))
+      const parsedAckMessage = parsedAckMessageA.name === 'PacketAck'
+        ? parsedAckMessageA
+        : parsedAckMessageB
 
-    expect(parsedAckMessage).toBeTruthy()
-    expect(getValueOf(parsedAckMessage, 'Packets', 0, 'ID')).toBe(0)
+      try {
+        expect(parsedAckMessage).toBeTruthy()
+        expect(getValueOf(parsedAckMessage, 'Packets', 0, 'ID')).toBe(0)
 
-    done()
-  }, 150)
+        resolve()
+      } catch (err) {
+        reject(err)
+      }
+    }, 150)
+  })
 })
 
-test('circuit should resend a package after 500ms', done => {
-  setTimeout(() => {
-    const last = circuit.websocket.getSendMessages()
+test('circuit should resend a package after 500ms', () => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const last = circuit.websocket.getSendMessages()
 
-    expect(last.readUInt8(6) | 32).toBeTruthy()
+      try {
+        expect(last.readUInt8(6) | 32).toBeTruthy()
 
-    done()
-  }, 400)
+        resolve()
+      } catch (err) {
+        reject(err)
+      }
+    }, 400)
+  })
 })
 
 describe('circuit should remove acks that the server has send back', () => {
@@ -327,7 +339,7 @@ describe('sending only 255 or less acks at the end of a package', () => {
   })
 })
 
-test('Acks are send 2 times with the PacketAck message', done => {
+test('Acks are send 2 times with the PacketAck message', () => {
   const check = expected => {
     for (const sequenceNumber in circuit.simAcks) {
       const sendCount = circuit.simAcks[sequenceNumber]
@@ -349,21 +361,23 @@ test('Acks are send 2 times with the PacketAck message', done => {
     }
   }
 
-  setTimeout(() => {
-    try {
-      circuit.websocket.onTestMessage = undefined
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      try {
+        circuit.websocket.onTestMessage = undefined
 
-      expect(messages.length).toBe(2)
-      expect(Object.keys(circuit.simAcks).length).toBe(0)
+        expect(messages.length).toBe(2)
+        expect(Object.keys(circuit.simAcks).length).toBe(0)
 
-      expect(messages[0].Packets.length).toBe(255)
-      expect(messages[1].Packets.length).toBe(255)
-    } catch (err) {
-      expect(err).toBeUndefined()
-    }
+        expect(messages[0].Packets.length).toBe(255)
+        expect(messages[1].Packets.length).toBe(255)
 
-    done()
-  }, 200)
+        resolve()
+      } catch (err) {
+        reject(err)
+      }
+    }, 200)
+  })
 })
 
 test('circuit closes', () => {

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -180,7 +180,7 @@ test('send ack at end of package', () => {
   ])
 })
 
-test('circuit should send after 200ms a PacketAck', done => {
+test('circuit should send after 100ms a PacketAck', done => {
   setTimeout(() => {
     // could be CompletePingCheck
     const ackMessage1 = circuit.websocket.sendMessages[circuit.websocket.sendMessages.length - 2]
@@ -195,7 +195,7 @@ test('circuit should send after 200ms a PacketAck', done => {
     expect(getValueOf(parsedAckMessage, 'Packets', 0, 'ID')).toBe(0)
 
     done()
-  }, 250)
+  }, 150)
 })
 
 test('circuit should resend a package after 500ms', done => {

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -142,10 +142,10 @@ test('save sender sequence number of reliable packages as ack', () => {
   websocket.onmessage({data: message1})
   websocket.onmessage({data: message2})
 
-  expect(circuit.simAcks).toEqual({
-    [sequenceNumberForTests - 2]: 0,
-    [sequenceNumberForTests - 1]: 0
-  })
+  expect(circuit.simAcks).toEqual(new Map([
+    [sequenceNumberForTests - 2, 0],
+    [sequenceNumberForTests - 1, 0]
+  ]))
   expect(circuit.simAcksOnPacket.toArray()).toEqual([
     sequenceNumberForTests - 2,
     sequenceNumberForTests - 1
@@ -166,10 +166,10 @@ test('send ack at end of package', () => {
   const last = sendMessages[sendMessages.length - 1]
 
   // Check if there are the correct number of acks
-  expect(circuit.simAcks).toEqual({
-    [sequenceNumberForTests - 2]: 0,
-    [sequenceNumberForTests - 1]: 0
-  })
+  expect(circuit.simAcks).toEqual(new Map([
+    [sequenceNumberForTests - 2, 0],
+    [sequenceNumberForTests - 1, 0]
+  ]))
   expect(circuit.simAcksOnPacket.isEmpty()).toBe(true)
   expect(last.byteLength).toBe(23)
   expect((last.readUInt8(6) | 0x10) > 0).toBe(true)
@@ -252,7 +252,7 @@ describe('sending only 255 or less acks at the end of a package', () => {
   let sendAcks = []
 
   test('circuit only sends less then 256 Acks', () => {
-    circuit.simAcks = []
+    circuit.simAcks.clear()
     circuit.simAcksOnPacket.clear()
 
     for (let i = 0; i < 300; ++i) {


### PR DESCRIPTION
Fixes #75.

Changes proposed in this pull request:

- Send a sequence number 2 times with PacketAck
- Send only 255 acks on a message or less if message is already big (Package max size is 1200 bytes)

Reviewer: @Terreii
