### PR TITLE
Autoscroll chat to bottom 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -913,6 +913,12 @@
         "postcss-value-parser": "^3.2.3"
       }
     },
+    "autoscroll-react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/autoscroll-react/-/autoscroll-react-3.2.0.tgz",
+      "integrity": "sha512-HOiwy9GGTSk9WZwEPd+FwNLLZ17o5wkjAtAb+RtQUr/2J1PT2KRG+OI6LoGtfY5EwWvQKAbSsjkgLvLhItscSg==",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "proxy": "http://localhost:8080",
   "devDependencies": {
     "@hoodie/client": "^10.1.1",
+    "autoscroll-react": "^3.2.0",
     "concurrently": "^3.5.1",
     "double-ended-queue": "^2.1.0-0",
     "immutable": "^3.8.2",

--- a/src/components/chatDialog.js
+++ b/src/components/chatDialog.js
@@ -6,31 +6,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Immutable from 'immutable'
 import styled from 'styled-components'
-import autoscroll from 'autoscroll-react'
+
+import ChatMessagesList from './chatMessagesList'
 
 const Main = styled.div`
   margin: 0.3em;
   display: flex;
   flex-direction: column;
-`
-
-const MessageList = styled.div`
-  flex: 1 1 100%;
-  overflow-y: scroll;
-  max-height: calc(100vh - 8em);
-`
-
-const Message = styled.div`
-  & > span {
-    padding-right: 0.3em;
-    font-size: 120%;
-  }
-`
-
-const AvatarName = styled.span`
-  :after {
-    content: ":";
-  }
 `
 
 const ChatTextSend = styled.div`
@@ -47,22 +29,6 @@ const TextBox = styled.input`
   flex: 4 0 auto;
   margin-right: 0.5em;
 `
-
-// Adds to all Numbers a leading zero if it has only one digit
-function leadingZero (num) {
-  return String(num).padStart(2, '0')
-}
-
-class ChatList extends React.Component {
-  render () {
-    const { messages, ...props } = this.props
-    return <MessageList {...props}>
-      {messages}
-    </MessageList>
-  }
-}
-
-const AutoScrollChatList = autoscroll(ChatList)
 
 export default class ChatDialog extends React.Component {
   constructor () {
@@ -81,31 +47,17 @@ export default class ChatDialog extends React.Component {
   }
 
   render () {
-    const msgData = this.props.isIM ? this.props.data.get('messages') : this.props.data
-    const messages = msgData.map(msg => {
-      const time = new Date(msg.get('time'))
-      const fromId = this.props.isIM ? msg.get('fromId') : msg.get('sourceID')
-      const name = this.props.names.get(fromId) || ''
-      return (
-        <Message key={time.getTime()}>
-          <span className='time'>
-            {leadingZero(time.getHours())}
-            :
-            {leadingZero(time.getMinutes())}
-            :
-            {leadingZero(time.getSeconds())}
-          </span>
-          <AvatarName>{name.toString()}</AvatarName>
-          <span className='messageText'>{msg.get('message')}</span>
-        </Message>
-      )
-    })
+    const messages = this.props.isIM ? this.props.data.get('messages') : this.props.data
 
     const placeholderText = 'Send ' +
       (this.props.isIM ? 'Instant Message' : 'to local chat')
 
     return <Main>
-      <AutoScrollChatList messages={messages} />
+      <ChatMessagesList
+        messages={messages}
+        isIM={this.props.isIM}
+        names={this.props.names}
+      />
       <ChatTextSend>
         <TextBox
           type='text'

--- a/src/components/chatDialog.js
+++ b/src/components/chatDialog.js
@@ -15,6 +15,8 @@ const Main = styled.div`
 
 const MessageList = styled.div`
   flex: 1 1 100%;
+  overflow-y: scroll;
+  max-height: calc(100vh - 8em);
 `
 
 const Message = styled.div`

--- a/src/components/chatDialog.js
+++ b/src/components/chatDialog.js
@@ -36,6 +36,9 @@ export default class ChatDialog extends React.Component {
     this.state = {
       text: ''
     }
+    this._boundChange = this._onChange.bind(this)
+    this._boundKeyDown = this._onKeyDown.bind(this)
+    this._boundClickSend = this._send.bind(this)
   }
 
   componentDidMount () {
@@ -64,9 +67,10 @@ export default class ChatDialog extends React.Component {
           name='chatInput'
           placeholder={placeholderText}
           value={this.state.text}
-          onChange={this._onChange.bind(this)}
-          onKeyDown={this._onKeyDown.bind(this)} />
-        <SendButton onClick={this._onClick.bind(this)}>
+          onChange={this._boundChange}
+          onKeyDown={this._boundKeyDown}
+        />
+        <SendButton onClick={this._boundClickSend}>
           send
         </SendButton>
       </ChatTextSend>
@@ -81,18 +85,11 @@ export default class ChatDialog extends React.Component {
 
   _onKeyDown (event) {
     if (event.keyCode === 13) {
-      event.preventDefault()
-      const text = this.state.text.trim()
-      if (text) {
-        this.props.sendTo(text)
-      }
-      this.setState({
-        text: ''
-      })
+      this._send(event)
     }
   }
 
-  _onClick (event) {
+  _send (event) {
     event.preventDefault()
     const text = this.state.text.trim()
     if (text) {

--- a/src/components/chatDialog.js
+++ b/src/components/chatDialog.js
@@ -6,6 +6,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Immutable from 'immutable'
 import styled from 'styled-components'
+import autoscroll from 'autoscroll-react'
 
 const Main = styled.div`
   margin: 0.3em;
@@ -52,6 +53,17 @@ function leadingZero (num) {
   return String(num).padStart(2, '0')
 }
 
+class ChatList extends React.Component {
+  render () {
+    const { messages, ...props } = this.props
+    return <MessageList {...props}>
+      {messages}
+    </MessageList>
+  }
+}
+
+const AutoScrollChatList = autoscroll(ChatList)
+
 export default class ChatDialog extends React.Component {
   constructor () {
     super()
@@ -93,9 +105,7 @@ export default class ChatDialog extends React.Component {
       (this.props.isIM ? 'Instant Message' : 'to local chat')
 
     return <Main>
-      <MessageList>
-        {messages}
-      </MessageList>
+      <AutoScrollChatList messages={messages} />
       <ChatTextSend>
         <TextBox
           type='text'

--- a/src/components/chatMessagesList.js
+++ b/src/components/chatMessagesList.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import styled from 'styled-components'
+import autoscroll from 'autoscroll-react'
+
+const MessageList = styled.div`
+  flex: 1 1 100%;
+  overflow-y: scroll;
+  max-height: calc(100vh - 8em);
+`
+
+const Message = styled.div`
+  & > span {
+    padding-right: 0.3em;
+    font-size: 120%;
+  }
+`
+
+const AvatarName = styled.span`
+  :after {
+    content: ":";
+  }
+`
+
+// Adds to all Numbers a leading zero if it has only one digit
+function leadingZero (num) {
+  return String(num).padStart(2, '0')
+}
+
+class ChatList extends React.Component {
+  render () {
+    const {messages, isIM, names, ...props} = this.props
+
+    const messagesLines = messages.map(msg => {
+      const time = new Date(msg.get('time'))
+      const fromId = isIM ? msg.get('fromId') : msg.get('sourceID')
+      const name = names.get(fromId) || ''
+      return (
+        <Message key={time.getTime()}>
+          <span className='time'>
+            {leadingZero(time.getHours())}
+            :
+            {leadingZero(time.getMinutes())}
+            :
+            {leadingZero(time.getSeconds())}
+          </span>
+          <AvatarName>{name.toString()}</AvatarName>
+          <span className='messageText'>{msg.get('message')}</span>
+        </Message>
+      )
+    })
+
+    return <MessageList {...props}>
+      {messagesLines}
+    </MessageList>
+  }
+}
+
+export default autoscroll(ChatList)

--- a/src/reducers/localChatReducer.js
+++ b/src/reducers/localChatReducer.js
@@ -1,23 +1,25 @@
 /*
- * Stores all LocalChat-Messanges
+ * Stores all LocalChat-Messages
  */
 
-import Immutable from 'immutable'
+import {Map, List} from 'immutable'
 
 // Filter the data
-export default function localChatReducer (state = Immutable.List(), action) {
+export default function localChatReducer (state = List(), action) {
   switch (action.type) {
     case 'ChatFromSimulator':
-      return state.push(Immutable.Map(action.msg))
+      // filter out start typing and end typing
+      if (action.msg.chatType === 4 || action.msg.chatType === 5) return state
+      return state.push(Map(action.msg))
 
     case 'didLogin':
       return action.localChatHistory
-        .reduce((chatData, msg) => chatData.push(Immutable.Map(msg)), state)
+        .reduce((chatData, msg) => chatData.push(Map(msg)), state)
         .sort((a, b) => a.get('time') - b.get('time'))
 
     case 'DidLogout':
     case 'UserWasKicked':
-      return Immutable.List()
+      return List()
 
     default:
       return state


### PR DESCRIPTION
Fixes #57.

Changes proposed in this pull request:

- Filter out start and end typing messages from local chat
- Make the chat view scrollable
- Automatically scroll chat message view to the bottom, if new messages arrive

Reviewer: @Terreii
