### PR TITLE
Greenkeeper/react burger menu 2.6.3

### DIFF
--- a/hoodie/README.md
+++ b/hoodie/README.md
@@ -6,7 +6,7 @@ On start `server.js` will get loaded. `client.js` would be the same, but for the
 
 ## Server
 
-The server is a [`Hapi` server](https://hapijs.com/). The `server.js` will be loaded as a *hapi-plugin*. It will then load following modules:
+The server is a [`Hapi` server](https://hapijs.com/). The `server.js` will get loaded as a *hapi-plugin*. It will then load following modules:
 
 File | Description
 -----|-----

--- a/package-lock.json
+++ b/package-lock.json
@@ -21231,9 +21231,9 @@
       }
     },
     "react-burger-menu": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/react-burger-menu/-/react-burger-menu-2.6.1.tgz",
-      "integrity": "sha512-BPwCExEzTz5pvMaptfrVrQcOGyPc0EYklPTwkDNig0uh70nQAGvWy+eYcV3Fa7B2HfUUbxvYXBzeGGf9tqNL+w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-burger-menu/-/react-burger-menu-2.6.3.tgz",
+      "integrity": "sha512-qED0dfwdYEnwqoggxIUxSD1g5Hbis0KCwiVxArV1XjB9GXVpiUS2mCvEwzY8+9KFiROl59vh/SmcFfF3c8oLfw==",
       "dev": true,
       "requires": {
         "browserify-optional": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prop-types": "^15.6.2",
     "rc-tabs": "^9.6.0",
     "react": "^16.7.0",
-    "react-burger-menu": "^2.6.1",
+    "react-burger-menu": "^2.6.3",
     "react-dom": "^16.7.0",
     "react-helmet": "^5.2.0",
     "react-redux": "^6.0.0",

--- a/src/README.md
+++ b/src/README.md
@@ -15,6 +15,7 @@ In this directory are the general and setup modules located. Most of the App is 
 - [`icons`](./icons) all icons and images.
 - [`network`](./network) contains the UDP-network lair.
 - [`reactors`](./reactors) contains functions that react to state changes and dispatch actions.
+- [`reducers`]('./reducers) update the state by reducing the old state and actions to the new state.
 - [`selectors`](./selectors) contains functions to access and derive state.
 - [`store`](./store) sets up the store.
 


### PR DESCRIPTION
Fixes #149.

Changes proposed in this pull request:

- Update react burger menu to v2.6.3
- Add missing reducers in list of `src`-readme

Reviewer: @Terreii
