### PR TITLE
Greenkeeper/react burger menu 2.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21380,9 +21380,9 @@
       }
     },
     "react-burger-menu": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/react-burger-menu/-/react-burger-menu-2.6.3.tgz",
-      "integrity": "sha512-qED0dfwdYEnwqoggxIUxSD1g5Hbis0KCwiVxArV1XjB9GXVpiUS2mCvEwzY8+9KFiROl59vh/SmcFfF3c8oLfw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/react-burger-menu/-/react-burger-menu-2.6.4.tgz",
+      "integrity": "sha512-INx1/irTIZQ7t+y4dg3FpKKKGGMc5hbic9teORhdFQ99OjYmLl71oYJ9EUzAATzZnaJNVBq0Vs0BlupSdtIylw==",
       "dev": true,
       "requires": {
         "browserify-optional": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prop-types": "^15.6.2",
     "rc-tabs": "^9.6.0",
     "react": "^16.8.1",
-    "react-burger-menu": "^2.6.3",
+    "react-burger-menu": "^2.6.4",
     "react-dom": "^16.8.1",
     "react-helmet": "^5.2.0",
     "react-redux": "^6.0.0",


### PR DESCRIPTION
Fixes #162.

Changes proposed in this pull request:

- Update `react-burger-menu` to v2.6.4