### PR TITLE
Add greenkeeper check on travis install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - "10"
   - "8"
 install:
-  - if [ "$TRAVIS_BRANCH" =~ /greenkeeper/ ]; then
+  - if [[ $TRAVIS_BRANCH =~ greenkeeper ]]; then
       npm install;
     else
       npm ci;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ node_js:
   - "node"
   - "10"
   - "8"
-install: npm install
+install:
+  - if [ $TRAVIS_BRANCH =~ /greenkeeper/ ]; then
+      npm install
+    else
+      npm ci
+    fi
 env:
   - CXX=g++-4.9
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ node_js:
   - "10"
   - "8"
 install:
-  - if [ $TRAVIS_BRANCH =~ /greenkeeper/ ]; then
-      npm install
+  - if [ "$TRAVIS_BRANCH" =~ /greenkeeper/ ]; then
+      npm install;
     else
-      npm ci
+      npm ci;
     fi
 env:
   - CXX=g++-4.9


### PR DESCRIPTION
Changes proposed in this pull request:

- Add check on travis
  - if the branch contains `greenkeeper` then use `npm install` to install the dependencies.
  - else use `npm ci`

Reviewer: @Terreii
