### PR TITLE
Selectors

### DIFF
--- a/src/actions/chatMessageActions.js
+++ b/src/actions/chatMessageActions.js
@@ -2,13 +2,15 @@
  * Every local chat and IM related action
  */
 
-import { getValueOf, getStringValueOf } from '../network/msgGetters'
 import { v4 as uuid } from 'uuid'
+
+import { getValueOf, getStringValueOf } from '../network/msgGetters'
 
 import { getShouldSaveChat, getLocalChat, getIMChats } from '../selectors/chat'
 import { getIsSignedIn } from '../selectors/viewer'
 import { getAvatarDataSaveId, getAgentId, getSessionId } from '../selectors/session'
 import { getAvatarNameById } from '../selectors/names'
+import { getRegionId, getParentEstateID, getPosition } from '../selectors/region'
 
 /*
  *
@@ -43,15 +45,14 @@ export function sendInstantMessage (text, to, id, dialog = 0) {
   return async (dispatch, getState, { circuit }) => {
     try {
       const activeState = getState()
-      const session = activeState.session
 
       const chat = getIMChats(activeState).find(chat => chat.get('chatUUID') === id)
 
       const agentID = getAgentId(activeState)
       const sessionID = getSessionId(activeState)
-      const parentEstateID = session.getIn(['regionInfo', 'ParentEstateID'])
-      const regionID = session.getIn(['regionInfo', 'regionID'])
-      const position = session.getIn(['position', 'position'])
+      const parentEstateID = getParentEstateID(activeState)
+      const regionID = getRegionId(activeState)
+      const position = getPosition(activeState)
       const fromAgentName = getAvatarNameById(activeState, agentID).getFullName()
       const binaryBucket = dialog === 17
         ? chat.get('name')

--- a/src/actions/chatMessageActions.js
+++ b/src/actions/chatMessageActions.js
@@ -9,7 +9,7 @@ import { getValueOf, getStringValueOf } from '../network/msgGetters'
 import { getShouldSaveChat, getLocalChat, getIMChats } from '../selectors/chat'
 import { getIsSignedIn } from '../selectors/viewer'
 import { getAvatarDataSaveId, getAgentId, getSessionId } from '../selectors/session'
-import { getAvatarNameById } from '../selectors/names'
+import { getAvatarNameById, getOwnAvatarName } from '../selectors/names'
 import { getRegionId, getParentEstateID, getPosition } from '../selectors/region'
 
 /*
@@ -53,7 +53,7 @@ export function sendInstantMessage (text, to, id, dialog = 0) {
       const parentEstateID = getParentEstateID(activeState)
       const regionID = getRegionId(activeState)
       const position = getPosition(activeState)
-      const fromAgentName = getAvatarNameById(activeState, agentID).getFullName()
+      const fromAgentName = getOwnAvatarName(activeState).getFullName()
       const binaryBucket = dialog === 17
         ? chat.get('name')
         : Buffer.from([])

--- a/src/actions/friendsActions.js
+++ b/src/actions/friendsActions.js
@@ -1,6 +1,7 @@
 import { fetchLLSD } from './llsd'
 
 import { getAgentId, getSessionId } from '../selectors/session'
+import { getFriends, getFriendById } from '../selectors/people'
 import { getNames, getDisplayNamesURL } from '../selectors/names'
 
 function sendUUIDNameRequest (ids) {
@@ -63,7 +64,7 @@ export function getAllFriendsDisplayNames () {
     const state = getState()
 
     const names = getNames(state)
-    const friendsIds = state.friends
+    const friendsIds = getFriends(state)
       .map(friend => friend.get('id'))
       .push(getAgentId(state)) // Add self
       .filter(id => !names.has(id) || !names.get(id).willHaveDisplayName()) // unknown only
@@ -80,7 +81,7 @@ export function updateRights (friendUUID, changedRights) {
     const state = getState()
 
     // Get friend
-    const friend = state.friends.find(friend => friend.get('id') === id)
+    const friend = getFriendById(state, id)
     if (friend == null) return
 
     const getRight = name => changedRights[name] == null

--- a/src/actions/friendsActions.js
+++ b/src/actions/friendsActions.js
@@ -1,6 +1,7 @@
 import { fetchLLSD } from './llsd'
 
-import { getNames } from '../selectors/names'
+import { getAgentId, getSessionId } from '../selectors/session'
+import { getNames, getDisplayNamesURL } from '../selectors/names'
 
 function sendUUIDNameRequest (ids) {
   return (dispatch, getState, { circuit }) => {
@@ -21,8 +22,9 @@ function loadDisplayNames (idsArray) {
   return (dispatch, getState) => {
     if (ids.length === 0) return
 
-    const fetchUrlString = getState().names.get('getDisplayNamesURL')
+    const fetchUrlString = getDisplayNamesURL(getState())
     if (fetchUrlString == null) return // Not jet loaded
+
     const fetchUrl = new window.URL(fetchUrlString)
     ids.forEach(id => fetchUrl.searchParams.append('ids', id))
 
@@ -63,7 +65,7 @@ export function getAllFriendsDisplayNames () {
     const names = getNames(state)
     const friendsIds = state.friends
       .map(friend => friend.get('id'))
-      .push(state.account.get('agentId')) // Add self
+      .push(getAgentId(state)) // Add self
       .filter(id => !names.has(id) || !names.get(id).willHaveDisplayName()) // unknown only
       .toArray()
 
@@ -75,8 +77,10 @@ export function getAllFriendsDisplayNames () {
 export function updateRights (friendUUID, changedRights) {
   const id = friendUUID.toString()
   return (dispatch, getState, { circuit }) => {
+    const state = getState()
+
     // Get friend
-    const friend = getState().friends.find(friend => friend.get('id') === id)
+    const friend = state.friends.find(friend => friend.get('id') === id)
     if (friend == null) return
 
     const getRight = name => changedRights[name] == null
@@ -90,12 +94,11 @@ export function updateRights (friendUUID, changedRights) {
 
     const rightsInt = (canSeeOnline << 0) | (canSeeOnMap << 1) | (canModifyObjects << 2)
 
-    const session = getState().session
     circuit.send('GrantUserRights', {
       AgentData: [
         {
-          AgentID: session.get('agentId'),
-          SessionID: session.get('sessionId')
+          AgentID: getAgentId(state),
+          SessionID: getSessionId(state)
         }
       ],
       Rights: [

--- a/src/actions/groupsActions.js
+++ b/src/actions/groupsActions.js
@@ -2,46 +2,46 @@
 
 import { startNewIMChat } from './chatMessageActions'
 
+import { getAgentId, getSessionId } from '../selectors/session'
+import { getAvatarNameById } from '../selectors/names'
+
 export function startGroupChat (groups) {
   return (dispatch, getState, { circuit }) => {
     const activeState = getState()
     const session = activeState.session
 
-    const agentID = session.get('agentId')
-    const sessionID = session.get('sessionId')
+    const agentID = getAgentId(activeState)
     const position = session.getIn(['position', 'position'])
-    const fromAgentName = activeState.names.getIn(['names', agentID]).getFullName()
     const binaryBucket = Buffer.from([])
     const time = new Date()
 
     groups.forEach(group => {
-      const groupId = group.id
       circuit.send('ImprovedInstantMessage', {
         AgentData: [
           {
             AgentID: agentID,
-            SessionID: sessionID
+            SessionID: getSessionId(activeState)
           }
         ],
         MessageBlock: [
           {
             FromGroup: false,
-            ToAgentID: groupId,
+            ToAgentID: group.id,
             ParentEstateID: 0,
             RegionID: '00000000-0000-0000-0000-000000000000',
             Position: position,
             Offline: 0,
             Dialog: 15,
-            ID: groupId,
+            ID: group.id,
             Timestamp: Math.floor(time.getTime() / 1000),
-            FromAgentName: fromAgentName,
+            FromAgentName: getAvatarNameById(activeState, agentID).getFullName(),
             Message: Buffer.from([]),
             BinaryBucket: binaryBucket
           }
         ]
       }, true)
 
-      dispatch(startNewIMChat(15, groupId, group.name))
+      dispatch(startNewIMChat(15, group.id, group.name))
     })
 
     dispatch({

--- a/src/actions/groupsActions.js
+++ b/src/actions/groupsActions.js
@@ -3,22 +3,21 @@
 import { startNewIMChat } from './chatMessageActions'
 
 import { getAgentId, getSessionId } from '../selectors/session'
-import { getAvatarNameById } from '../selectors/names'
+import { getOwnAvatarName } from '../selectors/names'
 import { getPosition } from '../selectors/region'
 
 export function startGroupChat (groups) {
   return (dispatch, getState, { circuit }) => {
     const activeState = getState()
 
-    const agentID = getAgentId(activeState)
     const AgentData = [
       {
-        AgentID: agentID,
+        AgentID: getAgentId(activeState),
         SessionID: getSessionId(activeState)
       }
     ]
     const position = getPosition(activeState)
-    const agentName = getAvatarNameById(activeState, agentID).getFullName()
+    const agentName = getOwnAvatarName(activeState).getFullName()
     const binaryBucket = Buffer.from([])
     const time = new Date()
 

--- a/src/actions/groupsActions.js
+++ b/src/actions/groupsActions.js
@@ -4,25 +4,27 @@ import { startNewIMChat } from './chatMessageActions'
 
 import { getAgentId, getSessionId } from '../selectors/session'
 import { getAvatarNameById } from '../selectors/names'
+import { getPosition } from '../selectors/region'
 
 export function startGroupChat (groups) {
   return (dispatch, getState, { circuit }) => {
     const activeState = getState()
-    const session = activeState.session
 
     const agentID = getAgentId(activeState)
-    const position = session.getIn(['position', 'position'])
+    const AgentData = [
+      {
+        AgentID: agentID,
+        SessionID: getSessionId(activeState)
+      }
+    ]
+    const position = getPosition(activeState)
+    const agentName = getAvatarNameById(activeState, agentID).getFullName()
     const binaryBucket = Buffer.from([])
     const time = new Date()
 
     groups.forEach(group => {
       circuit.send('ImprovedInstantMessage', {
-        AgentData: [
-          {
-            AgentID: agentID,
-            SessionID: getSessionId(activeState)
-          }
-        ],
+        AgentData,
         MessageBlock: [
           {
             FromGroup: false,
@@ -34,7 +36,7 @@ export function startGroupChat (groups) {
             Dialog: 15,
             ID: group.id,
             Timestamp: Math.floor(time.getTime() / 1000),
-            FromAgentName: getAvatarNameById(activeState, agentID).getFullName(),
+            FromAgentName: agentName,
             Message: Buffer.from([]),
             BinaryBucket: binaryBucket
           }

--- a/src/actions/llsd.js
+++ b/src/actions/llsd.js
@@ -1,7 +1,7 @@
 import LLSD from '../llsd'
 import caps from './capabilities.json'
 
-import { getIsLoggedIn, getAvatarIdentifier } from '../selectors/session'
+import { getAvatarIdentifier } from '../selectors/session'
 
 async function parseLLSD (response) {
   const body = await response.text()
@@ -59,7 +59,7 @@ async function * eventQueueGet (getState) {
   const avatarIdentifier = getAvatarIdentifier(getState())
   let ack = 0
 
-  while (getIsLoggedIn(getState()) && getAvatarIdentifier(getState()) === avatarIdentifier) {
+  while (getAvatarIdentifier(getState()) === avatarIdentifier) {
     let response
     try {
       response = await minimalFetchLLSD('POST', url, { done: false, ack })

--- a/src/actions/llsd.js
+++ b/src/actions/llsd.js
@@ -1,7 +1,7 @@
 import LLSD from '../llsd'
 import caps from './capabilities.json'
 
-import { getAvatarIdentifier } from '../selectors/session'
+import { getAvatarIdentifier, getEventQueueGetUrl } from '../selectors/session'
 
 async function parseLLSD (response) {
   const body = await response.text()
@@ -55,7 +55,7 @@ export function fetchSeedCapabilities (url) {
 
 // http://wiki.secondlife.com/wiki/EventQueueGet
 async function * eventQueueGet (getState) {
-  const url = getState().session.get('eventQueueGetUrl')
+  const url = getEventQueueGetUrl(getState())
   const avatarIdentifier = getAvatarIdentifier(getState())
   let ack = 0
 

--- a/src/actions/llsd.js
+++ b/src/actions/llsd.js
@@ -1,7 +1,8 @@
 import LLSD from '../llsd'
 import caps from './capabilities.json'
 
-import { getAvatarIdentifier, getEventQueueGetUrl } from '../selectors/session'
+import { getAvatarIdentifier } from '../selectors/session'
+import { getEventQueueGetUrl } from '../selectors/region'
 
 async function parseLLSD (response) {
   const body = await response.text()

--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -11,7 +11,7 @@ import { fetchSeedCapabilities } from './llsd'
 import connectCircuit from './connectCircuit'
 
 import { getSavedAvatars, getSavedGrids } from '../selectors/viewer'
-import { getIsLoggedIn } from '../selectors/session'
+import { getIsLoggedIn, getAgentId, getSessionId } from '../selectors/session'
 
 // Actions for the session of an avatar
 
@@ -128,7 +128,6 @@ export function logout () {
   return (dispatch, getState, extra) => {
     const circuit = extra.circuit
     const activeState = getState()
-    const session = activeState.session
 
     if (!getIsLoggedIn(activeState)) {
       return Promise.reject(new Error("You aren't logged in!"))
@@ -138,8 +137,8 @@ export function logout () {
       circuit.send('LogoutRequest', {
         AgentData: [
           {
-            AgentID: session.get('agentId'),
-            SessionID: session.get('sessionId')
+            AgentID: getAgentId(activeState),
+            SessionID: getSessionId(activeState)
           }
         ]
       }, true)
@@ -238,9 +237,9 @@ function connectToSim (sessionInfo, circuit) {
 
 function getKicked (msg) {
   return (dispatch, getState, extra) => {
-    const session = getState().session
-    const agentId = session.get('agentId')
-    const sessionId = session.get('sessionId')
+    const activeState = getState()
+    const agentId = getAgentId(activeState)
+    const sessionId = getSessionId(activeState)
     const msgAgentId = getValueOf(msg, 'UserInfo', 0, 'AgentID')
     const msgSessionId = getValueOf(msg, 'UserInfo', 0, 'SessionID')
 
@@ -270,9 +269,9 @@ function afterAvatarSessionEnds () {
 
 function requestAvatarProperties (avatarID) {
   return (dispatch, getState, { circuit }) => {
-    const session = getState().session
-    const agentID = session.get('agentId')
-    const sessionID = session.get('sessionId')
+    const activeState = getState()
+    const agentID = getAgentId(activeState)
+    const sessionID = getSessionId(activeState)
 
     circuit.send('AvatarPropertiesRequest', {
       AgentData: [

--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -20,13 +20,10 @@ export function login (avatarName, password, grid, save, isNew) {
   return async (dispatch, getState, extra) => {
     if (getIsLoggedIn(getState())) throw new Error('There is already an avatar logged in!')
 
-    const avatarIdentifier = `${avatarName.getFullName()}@${grid.name}`
-
     dispatch({
       type: 'startLogin',
       name: avatarName,
       grid,
-      avatarIdentifier,
       sync: save
     })
 
@@ -84,8 +81,10 @@ export function login (avatarName, password, grid, save, isNew) {
       await dispatch(saveGrid(grid))
     }
 
+    const avatarIdentifier = `${body.agent_id}@${grid.name}`
+
     const avatarData = save && isNew
-      ? await dispatch(saveAvatar(avatarName, grid.name)) // adding new avatars
+      ? await dispatch(saveAvatar(avatarName, body.agent_id, grid.name)) // adding new avatars
       : getSavedAvatars(getState()).reduce((last, avatar) => { // for saved avatars
         if (last != null) return last
 

--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -10,6 +10,7 @@ import { getAllFriendsDisplayNames } from './friendsActions'
 import { fetchSeedCapabilities } from './llsd'
 import connectCircuit from './connectCircuit'
 
+import { getSavedAvatars, getSavedGrids } from '../selectors/viewer'
 import { getIsLoggedIn } from '../selectors/session'
 
 // Actions for the session of an avatar
@@ -76,7 +77,7 @@ export function login (avatarName, password, grid, save, addAvatar) {
     }
 
     // save grid if it is new (do not save if login did fail)
-    const gridExists = getState().account.get('savedGrids').some(savedGrid => {
+    const gridExists = getSavedGrids(getState()).some(savedGrid => {
       return savedGrid.get('name') === grid.name
     })
     if (save && addAvatar && !gridExists) {
@@ -88,7 +89,7 @@ export function login (avatarName, password, grid, save, addAvatar) {
 
     const avatarData = save && addAvatar
       ? await dispatch(saveAvatar(avatarName, grid.name)) // adding new avatars
-      : getState().account.get('savedAvatars').reduce((last, avatar) => { // for saved avatars
+      : getSavedAvatars(getState()).reduce((last, avatar) => { // for saved avatars
         if (last != null) return last
 
         if (avatar.get('avatarIdentifier') === avatarIdentifier) {

--- a/src/actions/simAction.js
+++ b/src/actions/simAction.js
@@ -1,6 +1,8 @@
 import { receiveChatFromSimulator, receiveIM } from './chatMessageActions'
 import { getValueOf, mapBlockOf } from '../network/msgGetters'
 
+import { getAgentId, getSessionId } from '../selectors/session'
+
 // Gets all messages from the SIM and filters them, and if needed: calls their own actions.
 function simActionFilter (msg) {
   switch (msg.name) {
@@ -49,7 +51,7 @@ function parseUserRights (message) {
     })
     dispatch({
       type: 'ChangeUserRights',
-      ownId: getState().account.get('agentId'),
+      ownId: getAgentId(getState()),
       fromId: getValueOf(message, 'AgentData', 'AgentID'),
       userRights: rights
     })
@@ -61,13 +63,13 @@ function sendRegionHandshakeReply (RegionHandshake) {
     const regionID = getValueOf(RegionHandshake, 'RegionInfo2', 'RegionID')
     const flags = getValueOf(RegionHandshake, 'RegionInfo', 'RegionFlags')
 
-    const session = getState().session
+    const state = getState()
 
     circuit.send('RegionHandshakeReply', {
       AgentData: [
         {
-          AgentID: session.get('agentId'),
-          SessionID: session.get('sessionId')
+          AgentID: getAgentId(state),
+          SessionID: getSessionId(state)
         }
       ],
       RegionInfo: [

--- a/src/actions/viewerAccount.js
+++ b/src/actions/viewerAccount.js
@@ -141,7 +141,7 @@ export function saveGrid (newGrid) {
   return (dispatch, getState, { hoodie }) => {
     const name = newGrid.name.trim()
 
-    if (getSavedGrids(getState()).some(value => value.get('name') === name)) {
+    if (getSavedGrids(getState()).some(grid => grid.get('name') === name)) {
       return Promise.reject(new Error('Grid already exist!'))
     }
 
@@ -299,14 +299,13 @@ export function changeEncryptionPassword (resetKey, newPassword) {
 }
 
 export function signOut () {
-  return async (dispatch, getState, extra) => {
+  return async (dispatch, getState, { hoodie }) => {
     dispatch(closePopup())
     if (getIsLoggedIn(getState())) {
       // logout if an avatar is still logged in
       const { logout } = await import('./sessionActions')
       await dispatch(logout())
     }
-    const hoodie = extra.hoodie
 
     try {
       await hoodie.account.signOut()

--- a/src/actions/viewerAccount.js
+++ b/src/actions/viewerAccount.js
@@ -55,11 +55,11 @@ export function closePopup () {
   }
 }
 
-export function saveAvatar (name, grid) {
+export function saveAvatar (name, agentId, grid) {
   return (dispatch, getState, { hoodie }) => {
     const gridName = typeof grid === 'string' ? grid : grid.get('name')
 
-    const avatarIdentifier = `${name.getFullName()}@${gridName}`
+    const avatarIdentifier = `${agentId}@${gridName}`
 
     if (getSavedAvatars(getState()).some(avatar => {
       return avatar.get('avatarIdentifier') === avatarIdentifier

--- a/src/actions/viewerAccount.js
+++ b/src/actions/viewerAccount.js
@@ -2,6 +2,14 @@
 
 import { v4 as uuid } from 'uuid'
 
+import {
+  getIsSignedIn,
+  getIsUnlocked,
+  getSavedAvatars,
+  getSavedAvatarsAreLoaded,
+  getSavedGrids,
+  getSavedGridsAreLoaded
+} from '../selectors/viewer'
 import { getIsLoggedIn } from '../selectors/session'
 
 export function didSignIn (did, isUnlocked, username = '') {
@@ -53,7 +61,7 @@ export function saveAvatar (name, grid) {
 
     const avatarIdentifier = `${name.getFullName()}@${gridName}`
 
-    if (getState().account.get('savedAvatars').some(avatar => {
+    if (getSavedAvatars(getState()).some(avatar => {
       return avatar.get('avatarIdentifier') === avatarIdentifier
     })) {
       return Promise.reject(new Error('Avatar already exist!'))
@@ -70,13 +78,13 @@ export function saveAvatar (name, grid) {
 
 export function loadSavedAvatars () {
   return async (dispatch, getState, { hoodie }) => {
-    const account = getState().account
+    const activeState = getState()
 
-    if (!account.getIn(['viewerAccount', 'loggedIn'])) {
+    if (!getIsSignedIn(activeState)) {
       throw new Error('Not signed in to Viewer!')
     }
 
-    if (account.get('savedAvatarsLoaded')) return
+    if (getSavedAvatarsAreLoaded(activeState)) return
 
     const avatarsStore = hoodie.cryptoStore.withIdPrefix('avatars/')
 
@@ -133,7 +141,7 @@ export function saveGrid (newGrid) {
   return (dispatch, getState, { hoodie }) => {
     const name = newGrid.name.trim()
 
-    if (getState().account.get('savedGrids').some(value => value.get('name') === name)) {
+    if (getSavedGrids(getState()).some(value => value.get('name') === name)) {
       return Promise.reject(new Error('Grid already exist!'))
     }
 
@@ -146,13 +154,13 @@ export function saveGrid (newGrid) {
 
 export function loadSavedGrids () {
   return async (dispatch, getState, { hoodie }) => {
-    const account = getState().account
+    const activeState = getState()
 
-    if (!account.getIn(['viewerAccount', 'loggedIn'])) {
+    if (!getIsSignedIn(activeState)) {
       throw new Error('Not signed in to Viewer!')
     }
 
-    if (account.get('savedGridsLoaded')) return
+    if (getSavedGridsAreLoaded(activeState)) return
 
     const gridsStore = hoodie.cryptoStore.withIdPrefix('grids/')
 
@@ -209,11 +217,11 @@ export function isSignedIn () {
 export function unlock (cryptoPassword) {
   return async (dispatch, getState, { hoodie }) => {
     const activeState = getState()
-    if (activeState.account.get('unlocked')) {
+    if (getIsUnlocked(activeState)) {
       return
     }
 
-    if (!activeState.account.getIn(['viewerAccount', 'loggedIn'])) {
+    if (!getIsSignedIn(activeState)) {
       throw new Error('Not signed in!')
     }
 

--- a/src/components/burgerMenu.js
+++ b/src/components/burgerMenu.js
@@ -83,37 +83,41 @@ const GlobalStyles = createGlobalStyle`
 
 const SlideMenu = reduxBurgerMenu(Menu)
 
-export default function BurgerMenu ({ account, signIn, signUp, logout, signOut }) {
-  const avatarLoggedIn = account.get('loggedIn')
-  const avatarName = account.get('avatarName')
-  const viewerLoggedIn = account.getIn(['viewerAccount', 'loggedIn'])
-  const username = account.getIn(['viewerAccount', 'username'])
-
+export default function BurgerMenu ({
+  isSignedIn,
+  userName,
+  isLoggedIn,
+  avatarName,
+  signIn,
+  signUp,
+  logout,
+  signOut
+}) {
   return <SlideMenu>
     <GlobalStyles />
 
-    {avatarLoggedIn ? <MenuText>{`Hello ${avatarName}`}</MenuText> : null}
+    {isLoggedIn ? <MenuText>{`Hello ${avatarName}`}</MenuText> : null}
 
-    {viewerLoggedIn
-      ? <MenuText>{`Hello ${username}`}</MenuText>
+    {isSignedIn
+      ? <MenuText>{`Hello ${userName}`}</MenuText>
       : <MenuButton onClick={signIn}>Sign into Andromeda</MenuButton>
     }
 
-    {viewerLoggedIn
+    {isSignedIn
       ? null
       : <MenuButton className='menu-item' onClick={signUp}>
         Sign up to Andromeda
       </MenuButton>
     }
 
-    {avatarLoggedIn
+    {isLoggedIn
       ? <LogoutButton className='menu-item' onClick={logout}>
         log out
       </LogoutButton>
       : null
     }
 
-    {viewerLoggedIn
+    {isSignedIn
       ? <LogoutButton className='menu-item' onClick={signOut}>
         Log out from Viewer
       </LogoutButton>

--- a/src/components/burgerMenu.test.js
+++ b/src/components/burgerMenu.test.js
@@ -1,25 +1,17 @@
 import { axe } from 'jest-axe'
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import Immutable from 'immutable'
 import { Provider } from 'react-redux'
 
 import BurgerMenu from './burgerMenu'
 import configureStore from '../store/configureStore'
 
 test('renders without crashing', () => {
-  const account = Immutable.fromJS({
-    avatarName: '',
-    loggedIn: false,
-    viewerAccount: {
-      loggedIn: false,
-      username: '',
-      signInPopup: ''
-    }
-  })
-
   shallow(<BurgerMenu
-    account={account}
+    isSignedIn={false}
+    userName={''}
+    isLoggedIn={false}
+    avatarName={''}
     signIn={() => {}}
     signUp={() => {}}
     signOut={() => {}}
@@ -28,16 +20,6 @@ test('renders without crashing', () => {
 })
 
 test('click handling', () => {
-  const account = Immutable.fromJS({
-    avatarName: '',
-    loggedIn: false,
-    viewerAccount: {
-      loggedIn: false,
-      username: '',
-      signInPopup: ''
-    }
-  })
-
   let signInCount = 0
   let signUpCount = 0
   let signOutCount = 0
@@ -46,7 +28,10 @@ test('click handling', () => {
   // Nothing logged in
 
   const menu = shallow(<BurgerMenu
-    account={account}
+    isSignedIn={false}
+    userName={''}
+    isLoggedIn={false}
+    avatarName={''}
     signIn={() => {
       signInCount += 1
     }}
@@ -74,10 +59,10 @@ test('click handling', () => {
   // Avatar logged in
 
   const menuAvatarLoggedIn = shallow(<BurgerMenu
-    account={account.merge({
-      avatarName: 'Tester',
-      loggedIn: true
-    })}
+    isSignedIn={false}
+    userName={''}
+    isLoggedIn
+    avatarName={'Tester'}
     signIn={() => {
       signInCount += 1
     }}
@@ -106,12 +91,10 @@ test('click handling', () => {
   // Viewr account logged in
 
   const menuViewerSignedIn = shallow(<BurgerMenu
-    account={account.mergeDeep({
-      viewerAccount: {
-        loggedIn: true,
-        username: 'tester@test.org'
-      }
-    })}
+    isSignedIn
+    userName={'tester@test.org'}
+    isLoggedIn={false}
+    avatarName={''}
     signIn={() => {
       signInCount += 1
     }}
@@ -138,14 +121,10 @@ test('click handling', () => {
   // Viewer and avatar logged in
 
   const menuAllIn = shallow(<BurgerMenu
-    account={account.mergeDeep({
-      avatarName: 'Tester',
-      loggedIn: true,
-      viewerAccount: {
-        loggedIn: true,
-        username: 'tester@test.org'
-      }
-    })}
+    isSignedIn
+    userName={'tester@test.org'}
+    isLoggedIn
+    avatarName={'Tester'}
     signIn={() => {
       signInCount += 1
     }}
@@ -172,19 +151,12 @@ test('click handling', () => {
 })
 
 test('should pass aXe', async () => {
-  const account = Immutable.fromJS({
-    avatarName: '',
-    loggedIn: false,
-    viewerAccount: {
-      loggedIn: false,
-      username: '',
-      signInPopup: ''
-    }
-  })
-
   const rendered = mount(<Provider store={configureStore()}>
     <BurgerMenu
-      account={account}
+      isSignedIn={false}
+      userName={''}
+      isLoggedIn={false}
+      avatarName={''}
       signIn={() => {}}
       signUp={() => {}}
       signOut={() => {}}

--- a/src/components/topBar.js
+++ b/src/components/topBar.js
@@ -29,16 +29,28 @@ const ViewerName = styled.span`
   text-transform: capitalize;
 `
 
-export default function TopBar ({ account, signIn, signUp, signOut, logout }) {
+export default function TopBar ({
+  isSignedIn,
+  userName,
+  isLoggedIn,
+  avatarName,
+  signIn,
+  signUp,
+  signOut,
+  logout
+}) {
   return <MenuBar>
     <BurgerMenu
-      account={account}
+      isSignedIn={isSignedIn}
+      userName={userName}
+      isLoggedIn={isLoggedIn}
+      avatarName={avatarName}
       signIn={signIn}
       signUp={signUp}
       signOut={signOut}
       logout={logout}
     />
-    {account.getIn(['loggedIn'])
+    {isLoggedIn
       ? null
       : <span>Login to <ViewerName>{viewerName}</ViewerName></span>
     }

--- a/src/components/topBar.test.js
+++ b/src/components/topBar.test.js
@@ -1,42 +1,37 @@
 import { axe } from 'jest-axe'
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import Immutable from 'immutable'
 import { Provider } from 'react-redux'
 
 import TopBar from './topBar'
 import configureStore from '../store/configureStore'
 
 test('renders without crashing', () => {
-  const account = Immutable.fromJS({
-    avatarName: '',
-    loggedIn: false,
-    viewerAccount: {
-      loggedIn: false,
-      username: '',
-      signInPopup: ''
-    }
-  })
   shallow(<TopBar
-    account={account}
+    isSignedIn={false}
+    userName={''}
+    isLoggedIn={false}
+    avatarName={''}
+    signIn={() => {}}
+    signUp={() => {}}
+    signOut={() => {}}
+    logout={() => {}}
   />)
 })
 
 test('should pass aXe', async () => {
   const store = configureStore()
 
-  const account = Immutable.fromJS({
-    avatarName: '',
-    loggedIn: false,
-    viewerAccount: {
-      loggedIn: false,
-      username: '',
-      signInPopup: ''
-    }
-  })
   const rendered = mount(<Provider store={store}>
     <TopBar
-      account={account}
+      isSignedIn={false}
+      userName={''}
+      isLoggedIn={false}
+      avatarName={''}
+      signIn={() => {}}
+      signUp={() => {}}
+      signOut={() => {}}
+      logout={() => {}}
     />
   </Provider>)
 

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -26,6 +26,11 @@ import {
 } from '../actions/viewerAccount'
 import { login } from '../actions/sessionActions'
 
+import {
+  getIsSignedIn,
+  getSavedAvatars,
+  getSavedGrids
+} from '../selectors/viewer'
 import { getIsLoggedIn } from '../selectors/session'
 import { selectPopup, selectPopupData } from '../selectors/popup'
 
@@ -72,15 +77,11 @@ class App extends React.PureComponent {
 }
 
 const mapStateToProps = state => {
-  const avatars = state.account.get('savedAvatars')
-  const grids = state.account.get('savedGrids')
-  const isSignedIn = state.account.getIn(['viewerAccount', 'loggedIn'])
-
   return {
-    avatars,
-    grids,
+    avatars: getSavedAvatars(state),
+    grids: getSavedGrids(state),
     isLoggedIn: getIsLoggedIn(state), // Avatar session
-    isSignedIn, // Viewer account
+    isSignedIn: getIsSignedIn(state), // Viewer account
     popup: selectPopup(state),
     popupData: selectPopupData(state)
   }

--- a/src/containers/chatContainer.js
+++ b/src/containers/chatContainer.js
@@ -10,6 +10,8 @@ import { updateRights } from '../actions/friendsActions'
 
 import { getLocalChat, getActiveIMChats } from '../selectors/chat'
 import { getNames } from '../selectors/names'
+import { getFriends } from '../selectors/people'
+import { getGroups } from '../selectors/groups'
 
 import ChatBox from '../components/chatBox'
 
@@ -17,9 +19,9 @@ const mapStateToProps = state => {
   return {
     localChat: getLocalChat(state),
     IMs: getActiveIMChats(state),
-    groups: state.groups,
+    groups: getGroups(state),
     names: getNames(state),
-    friends: state.friends
+    friends: getFriends(state)
   }
 }
 

--- a/src/containers/helmet.js
+++ b/src/containers/helmet.js
@@ -4,6 +4,8 @@ import Helmet from 'react-helmet'
 
 import { viewerName } from '../viewerInfo'
 
+import { getIsLoggedIn, getAvatarName } from '../selectors/session'
+
 function HelmetContainer ({ isLoggedIn, selfName }) {
   return <Helmet
     defaultTitle={isLoggedIn
@@ -15,8 +17,8 @@ function HelmetContainer ({ isLoggedIn, selfName }) {
 
 const mapStateToProps = state => {
   return {
-    selfName: state.account.get('avatarName'),
-    isLoggedIn: state.session.get('loggedIn')
+    selfName: getAvatarName(state),
+    isLoggedIn: getIsLoggedIn(state)
   }
 }
 

--- a/src/containers/helmet.js
+++ b/src/containers/helmet.js
@@ -4,7 +4,8 @@ import Helmet from 'react-helmet'
 
 import { viewerName } from '../viewerInfo'
 
-import { getIsLoggedIn, getAvatarName } from '../selectors/session'
+import { getIsLoggedIn } from '../selectors/session'
+import { getOwnAvatarName } from '../selectors/names'
 
 function HelmetContainer ({ isLoggedIn, selfName }) {
   return <Helmet
@@ -17,7 +18,7 @@ function HelmetContainer ({ isLoggedIn, selfName }) {
 
 const mapStateToProps = state => {
   return {
-    selfName: getAvatarName(state),
+    selfName: getOwnAvatarName(state),
     isLoggedIn: getIsLoggedIn(state)
   }
 }

--- a/src/containers/topMenuBar.js
+++ b/src/containers/topMenuBar.js
@@ -7,6 +7,9 @@ import TopBar from '../components/topBar'
 import { logout } from '../actions/sessionActions'
 import { showSignOutPopup, showSignInPopup } from '../actions/viewerAccount'
 
+import { getIsSignedIn, getUserName } from '../selectors/viewer'
+import { getIsLoggedIn, getAvatarName } from '../selectors/session'
+
 class TopBarContainer extends React.Component {
   constructor () {
     super()
@@ -42,7 +45,10 @@ class TopBarContainer extends React.Component {
 
   render () {
     return <TopBar
-      account={this.props.account}
+      isSignedIn={this.props.isSignedIn}
+      userName={this.props.userName}
+      isLoggedIn={this.props.isLoggedIn}
+      avatarName={this.props.avatarName}
       signIn={this._boundSignIn}
       signUp={this._boundSignUp}
       signOut={this._boundSignOut}
@@ -53,7 +59,10 @@ class TopBarContainer extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    account: state.account
+    isSignedIn: getIsSignedIn(state),
+    userName: getUserName(state),
+    isLoggedIn: getIsLoggedIn(state),
+    avatarName: getAvatarName(state)
   }
 }
 

--- a/src/containers/topMenuBar.js
+++ b/src/containers/topMenuBar.js
@@ -8,7 +8,8 @@ import { logout } from '../actions/sessionActions'
 import { showSignOutPopup, showSignInPopup } from '../actions/viewerAccount'
 
 import { getIsSignedIn, getUserName } from '../selectors/viewer'
-import { getIsLoggedIn, getAvatarName } from '../selectors/session'
+import { getIsLoggedIn } from '../selectors/session'
+import { getOwnAvatarName } from '../selectors/names'
 
 class TopBarContainer extends React.Component {
   constructor () {
@@ -62,7 +63,7 @@ const mapStateToProps = state => {
     isSignedIn: getIsSignedIn(state),
     userName: getUserName(state),
     isLoggedIn: getIsLoggedIn(state),
-    avatarName: getAvatarName(state)
+    avatarName: getOwnAvatarName(state)
   }
 }
 

--- a/src/reactors/group.js
+++ b/src/reactors/group.js
@@ -2,15 +2,13 @@ import { createSelector } from 'reselect'
 
 import { startGroupChat } from '../actions/groupsActions'
 
+import { getGroupsWithNoActiveChat } from '../selectors/groups'
+
 export const groupsDidLoad = createSelector(
   [
-    state => state.groups
+    getGroupsWithNoActiveChat
   ],
-  groups => {
-    const groupsWithNoImSession = groups.filter(group => !group.get('sessionStarted'))
-
-    if (groupsWithNoImSession.size === 0) return null
-
-    return startGroupChat(groupsWithNoImSession.toJSON())
-  }
+  groupsWithNoImSession => groupsWithNoImSession.size !== 0
+    ? startGroupChat(groupsWithNoImSession.toJSON())
+    : null
 )

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -3,17 +3,15 @@ import Immutable from 'immutable'
 function getDefault () {
   const defaultData = {
     avatarIdentifier: '',
-    avatarDataSaveId: '',
     sync: false,
     unlocked: false,
-    viewerAccount: {
-      loggedIn: false,
-      username: '',
-      signInPopup: '',
-      popupData: null
-    },
+    loggedIn: false,
+    username: '',
+    signInPopup: '',
+    popupData: null,
     savedAvatars: [],
     savedAvatarsLoaded: false,
+    anonymAvatarData: null,
     savedGrids: [
       {
         name: 'Second Life',
@@ -42,25 +40,33 @@ export default function accountReducer (state = getDefault(), action) {
       })
 
     case 'didLogin':
-      return state.merge({
-        avatarIdentifier: action.avatarIdentifier,
-        avatarDataSaveId: action.dataSaveId
-      })
+      if (action.save) {
+        return state.merge({
+          avatarIdentifier: action.avatarIdentifier
+        })
+      } else { // Anonym
+        return state.merge({
+          avatarIdentifier: action.avatarIdentifier,
+          anonymAvatarData: Immutable.Map({
+            grid: action.grid.name,
+            name: action.name.getFullName(),
+            avatarIdentifier: action.avatarIdentifier,
+            dataSaveId: action.dataSaveId
+          })
+        })
+      }
 
     case 'loginDidFail':
       return state.merge({
         avatarIdentifier: '',
-        avatarDataSaveId: '',
         sync: false
       })
 
     case 'ViewerAccountLogInStatus':
-      return state.mergeDeep({
+      return state.merge({
         unlocked: action.isUnlocked == null ? state.get('unlocked') : action.isUnlocked,
-        viewerAccount: {
-          loggedIn: action.isLoggedIn,
-          username: action.username
-        }
+        loggedIn: action.isLoggedIn,
+        username: action.username
       })
 
     case 'ViewerAccountSignOut':
@@ -73,40 +79,30 @@ export default function accountReducer (state = getDefault(), action) {
 
     case 'ShowSignInPopup':
       return state.mergeDeep({
-        viewerAccount: {
-          signInPopup: action.popup
-        }
+        signInPopup: action.popup
       })
 
     case 'ShowSignOutPopup':
       return state.mergeDeep({
-        viewerAccount: {
-          signInPopup: 'signOut'
-        }
+        signInPopup: 'signOut'
       })
 
     case 'SHOW_PASSWORD_RESET':
       return state.mergeDeep({
-        viewerAccount: {
-          signInPopup: 'resetPassword',
-          popupData: action.passwordType
-        }
+        signInPopup: 'resetPassword',
+        popupData: action.passwordType
       })
 
     case 'DISPLAY_VIEWER_ACCOUNT_RESET_KEYS':
       return state.mergeDeep({
-        viewerAccount: {
-          signInPopup: 'resetKeys',
-          popupData: action.resetKeys
-        }
+        signInPopup: 'resetKeys',
+        popupData: action.resetKeys
       })
 
     case 'ClosePopup':
       return state.mergeDeep({
-        viewerAccount: {
-          signInPopup: '',
-          popupData: null
-        }
+        signInPopup: '',
+        popupData: null
       })
 
     case 'AvatarSaved':
@@ -168,7 +164,7 @@ export default function accountReducer (state = getDefault(), action) {
     case 'UserWasKicked':
       return state.merge({
         avatarIdentifier: '',
-        avatarDataSaveId: '',
+        anonymAvatarData: null,
         sync: false
       })
 

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -2,13 +2,10 @@ import Immutable from 'immutable'
 
 function getDefault () {
   const defaultData = {
-    avatarName: '',
-    loggedIn: false,
     avatarIdentifier: '',
     avatarDataSaveId: '',
     sync: false,
     unlocked: false,
-    agentId: '',
     viewerAccount: {
       loggedIn: false,
       username: '',
@@ -40,24 +37,18 @@ export default function accountReducer (state = getDefault(), action) {
   switch (action.type) {
     case 'startLogin':
       return state.merge({
-        avatarName: action.name,
         avatarIdentifier: action.avatarIdentifier,
         sync: action.sync
       })
 
     case 'didLogin':
       return state.merge({
-        avatarName: action.name,
-        loggedIn: true,
         avatarIdentifier: action.avatarIdentifier,
-        avatarDataSaveId: action.dataSaveId,
-        agentId: action.uuid
+        avatarDataSaveId: action.dataSaveId
       })
 
     case 'loginDidFail':
       return state.merge({
-        avatarName: '',
-        loggedIn: false,
         avatarIdentifier: '',
         avatarDataSaveId: '',
         sync: false
@@ -176,12 +167,9 @@ export default function accountReducer (state = getDefault(), action) {
     case 'DidLogout':
     case 'UserWasKicked':
       return state.merge({
-        avatarName: '',
-        loggedIn: false,
         avatarIdentifier: '',
         avatarDataSaveId: '',
-        sync: false,
-        agentId: ''
+        sync: false
       })
 
     default:

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -2,7 +2,6 @@ import Immutable from 'immutable'
 
 function getDefault () {
   const defaultData = {
-    avatarIdentifier: '',
     sync: false,
     unlocked: false,
     loggedIn: false,
@@ -33,20 +32,14 @@ function getDefault () {
 
 export default function accountReducer (state = getDefault(), action) {
   switch (action.type) {
-    case 'startLogin':
-      return state.merge({
-        avatarIdentifier: action.avatarIdentifier,
-        sync: action.sync
-      })
-
     case 'didLogin':
       if (action.save) {
         return state.merge({
-          avatarIdentifier: action.avatarIdentifier
+          sync: action.save
         })
       } else { // Anonym
         return state.merge({
-          avatarIdentifier: action.avatarIdentifier,
+          sync: action.save,
           anonymAvatarData: Immutable.Map({
             grid: action.grid.name,
             name: action.name.getFullName(),
@@ -58,7 +51,6 @@ export default function accountReducer (state = getDefault(), action) {
 
     case 'loginDidFail':
       return state.merge({
-        avatarIdentifier: '',
         sync: false
       })
 
@@ -163,7 +155,6 @@ export default function accountReducer (state = getDefault(), action) {
     case 'DidLogout':
     case 'UserWasKicked':
       return state.merge({
-        avatarIdentifier: '',
         anonymAvatarData: null,
         sync: false
       })

--- a/src/reducers/sessionReducer.js
+++ b/src/reducers/sessionReducer.js
@@ -2,7 +2,7 @@ import { Map } from 'immutable'
 
 import { getValueOf, getValuesOf } from '../network/msgGetters'
 
-export default function SessionReducer (state = Map({ loggedIn: false, error: null }), action) {
+export default function SessionReducer (state = Map({ error: null }), action) {
   switch (action.type) {
     case 'didLogin':
       const sessionInfo = Object.keys(action.sessionInfo).reduce((info, key) => {
@@ -28,7 +28,6 @@ export default function SessionReducer (state = Map({ loggedIn: false, error: nu
             return info
         }
       }, {})
-      sessionInfo.loggedIn = true
       sessionInfo.position = Map({
         position: [],
         lookAt: JSON.parse(action.sessionInfo.look_at.replace(/r/gi, ''))
@@ -64,7 +63,6 @@ export default function SessionReducer (state = Map({ loggedIn: false, error: nu
     case 'DidLogout':
     case 'UserWasKicked':
       return Map({
-        loggedIn: false,
         error: action.type === 'UserWasKicked' ? action.reason : null
       })
 

--- a/src/reducers/sessionReducer.js
+++ b/src/reducers/sessionReducer.js
@@ -2,7 +2,10 @@ import { Map } from 'immutable'
 
 import { getValueOf, getValuesOf } from '../network/msgGetters'
 
-export default function SessionReducer (state = Map({ error: null }), action) {
+export default function sessionReducer (state = Map({
+  avatarIdentifier: null,
+  error: null
+}), action) {
   switch (action.type) {
     case 'didLogin':
       const sessionInfo = Object.keys(action.sessionInfo).reduce((info, key) => {
@@ -28,6 +31,7 @@ export default function SessionReducer (state = Map({ error: null }), action) {
             return info
         }
       }, {})
+      sessionInfo.avatarIdentifier = action.avatarIdentifier
       sessionInfo.position = Map({
         position: [],
         lookAt: JSON.parse(action.sessionInfo.look_at.replace(/r/gi, ''))
@@ -63,6 +67,7 @@ export default function SessionReducer (state = Map({ error: null }), action) {
     case 'DidLogout':
     case 'UserWasKicked':
       return Map({
+        avatarIdentifier: null,
         error: action.type === 'UserWasKicked' ? action.reason : null
       })
 

--- a/src/selectors/chat.js
+++ b/src/selectors/chat.js
@@ -1,4 +1,8 @@
+// Selectors for chat (local chat and IMs)
+
 import { createSelector } from 'reselect'
+
+import { getIsSignedIn, getShouldSync } from './viewer'
 
 export const getLocalChat = state => state.localChat
 
@@ -14,7 +18,8 @@ export const getActiveIMChats = createSelector(
 // checks if the chat history should be saved and synced
 export const getShouldSaveChat = createSelector(
   [
-    state => state.account
+    getShouldSync,
+    getIsSignedIn
   ],
-  account => account.get('sync') && account.getIn(['viewerAccount', 'loggedIn'])
+  (sync, isSignedIn) => sync && isSignedIn
 )

--- a/src/selectors/groups.js
+++ b/src/selectors/groups.js
@@ -1,0 +1,12 @@
+// Selectors for groups
+
+import { createSelector } from 'reselect'
+
+export const getGroups = state => state.groups
+
+export const getGroupsWithNoActiveChat = createSelector(
+  [
+    getGroups
+  ],
+  groups => groups.filter(group => !group.get('sessionStarted'))
+)

--- a/src/selectors/names.js
+++ b/src/selectors/names.js
@@ -1,3 +1,7 @@
 // Selectors for names
 
 export const getNames = state => state.names.get('names')
+
+export const getAvatarNameById = (state, id) => state.names.getIn(['names', id])
+
+export const getDisplayNamesURL = state => state.names.get('getDisplayNamesURL')

--- a/src/selectors/names.js
+++ b/src/selectors/names.js
@@ -1,7 +1,22 @@
 // Selectors for names
 
+import { createSelector } from 'reselect'
+
+import { getIsLoggedIn, getAgentId } from './session'
+
 export const getNames = state => state.names.get('names')
 
 export const getAvatarNameById = (state, id) => state.names.getIn(['names', id])
 
 export const getDisplayNamesURL = state => state.names.get('getDisplayNamesURL')
+
+export const getOwnAvatarName = createSelector(
+  [
+    getIsLoggedIn,
+    getAgentId,
+    getNames
+  ],
+  (isLoggedIn, agentId, names) => isLoggedIn
+    ? names.get(agentId)
+    : null
+)

--- a/src/selectors/people.js
+++ b/src/selectors/people.js
@@ -1,0 +1,6 @@
+// Selectors for friends and other people
+
+export const getFriends = state => state.friends
+
+export const getFriendById = (state, friendId) => getFriends(state)
+  .find(friend => friend.get('id') === friendId)

--- a/src/selectors/popup.js
+++ b/src/selectors/popup.js
@@ -7,7 +7,7 @@ export const selectPopup = createSelector(
   [
     getIsSignedIn,
     getIsUnlocked,
-    state => state.account.getIn(['viewerAccount', 'signInPopup']),
+    state => state.account.get('signInPopup'),
     getErrorMessage
   ],
   (isSignedIn, isUnlocked, signInPopup, sessionError) => {
@@ -21,4 +21,4 @@ export const selectPopup = createSelector(
   }
 )
 
-export const selectPopupData = state => state.account.getIn(['viewerAccount', 'popupData'])
+export const selectPopupData = state => state.account.get('popupData')

--- a/src/selectors/popup.js
+++ b/src/selectors/popup.js
@@ -1,16 +1,17 @@
 import { createSelector } from 'reselect'
 
+import { getIsSignedIn, getIsUnlocked } from './viewer'
 import { getErrorMessage } from './session'
 
 export const selectPopup = createSelector(
   [
-    state => state.account,
+    getIsSignedIn,
+    getIsUnlocked,
+    state => state.account.getIn(['viewerAccount', 'signInPopup']),
     getErrorMessage
   ],
-  (account, sessionError) => {
-    const isUnlocked = account.get('unlocked')
-    const isSignedIn = account.getIn(['viewerAccount', 'loggedIn'])
-    const popup = account.getIn(['viewerAccount', 'signInPopup']) || sessionError
+  (isSignedIn, isUnlocked, signInPopup, sessionError) => {
+    const popup = signInPopup || sessionError
 
     if (popup === 'resetPassword') return popup
 

--- a/src/selectors/region.js
+++ b/src/selectors/region.js
@@ -1,0 +1,9 @@
+// Selectors for SIM, region, position and movement
+
+export const getRegionId = state => state.session.getIn(['regionInfo', 'regionID'])
+
+export const getParentEstateID = state => state.session.getIn(['regionInfo', 'ParentEstateID'])
+
+export const getPosition = state => state.session.getIn(['position', 'position'])
+
+export const getEventQueueGetUrl = state => state.session.get('eventQueueGetUrl')

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -1,3 +1,5 @@
+// Selectors for general session-data
+
 export const getIsLoggedIn = state => state.session.get('loggedIn')
 
 export const getAvatarName = state => state.account.get('avatarName')
@@ -11,5 +13,3 @@ export const getErrorMessage = state => state.session.get('error')
 export const getAgentId = state => state.session.get('agentId')
 
 export const getSessionId = state => state.session.get('sessionId')
-
-export const getEventQueueGetUrl = state => state.session.get('eventQueueGetUrl')

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -1,5 +1,9 @@
 export const getIsLoggedIn = state => state.session.get('loggedIn')
 
+export const getAvatarName = state => state.account.get('avatarName')
+
 export const getAvatarIdentifier = state => state.account.get('avatarIdentifier')
+
+export const getAvatarDataSaveId = state => state.account.get('avatarDataSaveId')
 
 export const getErrorMessage = state => state.session.get('error')

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -7,3 +7,9 @@ export const getAvatarIdentifier = state => state.account.get('avatarIdentifier'
 export const getAvatarDataSaveId = state => state.account.get('avatarDataSaveId')
 
 export const getErrorMessage = state => state.session.get('error')
+
+export const getAgentId = state => state.session.get('agentId')
+
+export const getSessionId = state => state.session.get('sessionId')
+
+export const getEventQueueGetUrl = state => state.session.get('eventQueueGetUrl')

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -2,9 +2,27 @@
 
 import { createSelector } from 'reselect'
 
+import { getSavedAvatars, getAnonymAvatarData } from './viewer'
+
 export const getAvatarIdentifier = state => state.account.get('avatarIdentifier')
 
-export const getAvatarDataSaveId = state => state.account.get('avatarDataSaveId')
+export const getCurrentAvatarData = createSelector(
+  [
+    getSavedAvatars,
+    getAnonymAvatarData,
+    getAvatarIdentifier
+  ],
+  (savedAvatars, anonymAvatarData, avatarIdentifier) => anonymAvatarData != null
+    ? anonymAvatarData
+    : savedAvatars.find(avatarData => avatarData.get('avatarIdentifier') === avatarIdentifier)
+)
+
+export const getAvatarDataSaveId = createSelector(
+  [
+    getCurrentAvatarData
+  ],
+  avatarData => avatarData.get('dataSaveId')
+)
 
 export const getErrorMessage = state => state.session.get('error')
 

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -1,8 +1,6 @@
 // Selectors for general session-data
 
-export const getIsLoggedIn = state => state.session.get('loggedIn')
-
-export const getAvatarName = state => state.account.get('avatarName')
+import { createSelector } from 'reselect'
 
 export const getAvatarIdentifier = state => state.account.get('avatarIdentifier')
 
@@ -13,3 +11,13 @@ export const getErrorMessage = state => state.session.get('error')
 export const getAgentId = state => state.session.get('agentId')
 
 export const getSessionId = state => state.session.get('sessionId')
+
+export const getIsLoggedIn = createSelector(
+  [
+    getAvatarIdentifier,
+    getSessionId
+  ],
+  (avatarIdentifier, sessionId) => avatarIdentifier != null &&
+    avatarIdentifier.length > 0 &&
+    sessionId != null
+)

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect'
 
 import { getSavedAvatars, getAnonymAvatarData } from './viewer'
 
-export const getAvatarIdentifier = state => state.account.get('avatarIdentifier')
+export const getAvatarIdentifier = state => state.session.get('avatarIdentifier')
 
 export const getCurrentAvatarData = createSelector(
   [
@@ -35,7 +35,5 @@ export const getIsLoggedIn = createSelector(
     getAvatarIdentifier,
     getSessionId
   ],
-  (avatarIdentifier, sessionId) => avatarIdentifier != null &&
-    avatarIdentifier.length > 0 &&
-    sessionId != null
+  (avatarIdentifier, sessionId) => avatarIdentifier != null && sessionId != null
 )

--- a/src/selectors/viewer.js
+++ b/src/selectors/viewer.js
@@ -1,15 +1,17 @@
 // Selectors for viewer:
 // Account and other general state
 
-export const getIsSignedIn = state => state.account.getIn(['viewerAccount', 'loggedIn'])
+export const getIsSignedIn = state => state.account.get('loggedIn')
 
 export const getIsUnlocked = state => state.account.get('unlocked')
 
-export const getUserName = state => state.account.getIn(['viewerAccount', 'username'])
+export const getUserName = state => state.account.get('username')
 
 export const getSavedAvatars = state => state.account.get('savedAvatars')
 
 export const getSavedAvatarsAreLoaded = state => state.account.get('savedAvatarsLoaded')
+
+export const getAnonymAvatarData = state => state.account.get('anonymAvatarData')
 
 export const getSavedGrids = state => state.account.get('savedGrids')
 

--- a/src/selectors/viewer.js
+++ b/src/selectors/viewer.js
@@ -5,6 +5,8 @@ export const getIsSignedIn = state => state.account.getIn(['viewerAccount', 'log
 
 export const getIsUnlocked = state => state.account.get('unlocked')
 
+export const getUserName = state => state.account.getIn(['viewerAccount', 'username'])
+
 export const getSavedAvatars = state => state.account.get('savedAvatars')
 
 export const getSavedAvatarsAreLoaded = state => state.account.get('savedAvatarsLoaded')

--- a/src/selectors/viewer.js
+++ b/src/selectors/viewer.js
@@ -1,0 +1,14 @@
+// Selectors for viewer:
+// Account and other general state
+
+export const getIsSignedIn = state => state.account.getIn(['viewerAccount', 'loggedIn'])
+
+export const getIsUnlocked = state => state.account.get('unlocked')
+
+export const getSavedAvatars = state => state.account.get('savedAvatars')
+
+export const getSavedAvatarsAreLoaded = state => state.account.get('savedAvatarsLoaded')
+
+export const getSavedGrids = state => state.account.get('savedGrids')
+
+export const getSavedGridsAreLoaded = state => state.account.get('savedGridsLoaded')

--- a/src/selectors/viewer.js
+++ b/src/selectors/viewer.js
@@ -14,3 +14,5 @@ export const getSavedAvatarsAreLoaded = state => state.account.get('savedAvatars
 export const getSavedGrids = state => state.account.get('savedGrids')
 
 export const getSavedGridsAreLoaded = state => state.account.get('savedGridsLoaded')
+
+export const getShouldSync = state => state.account.get('sync')


### PR DESCRIPTION
Fixes #157.

Changes proposed in this pull request:

- Only use selectors for accessing state.
- Use `reselect` to derive some state.
- Move all state related to a session from `account.js` to `sessionReducer.js`
- Change `avatarIdentifier` to now use the `agentId` returned from the grid on login.

Reviewer: @Terreii
