### PR TITLE
Add save guards to friendsReducer and inventory

### DIFF
--- a/src/reducers/friendsReducer.js
+++ b/src/reducers/friendsReducer.js
@@ -13,6 +13,9 @@ function parseRights (rights) {
 export default function friendsReducer (state = [], action) {
   switch (action.type) {
     case 'didLogin':
+      // If a avatar has no buddies, then the buddy-list doesn't exist!
+      if (!Array.isArray(action.sessionInfo['buddy-list'])) return state
+
       return action.sessionInfo['buddy-list'].map(friend => {
         const rightsGiven = friend['buddy_rights_given'] // from me to friend
         const rightsHas = friend['rights_has'] // Friend has given me rights

--- a/src/reducers/inventory.js
+++ b/src/reducers/inventory.js
@@ -3,6 +3,12 @@
 export default function inventory (state = { root: null, folders: new Map() }, action) {
   switch (action.type) {
     case 'didLogin':
+      // save guard if the login result has no inventory-skeleton
+      if (!Array.isArray(action.sessionInfo['inventory-skeleton'])) {
+        console.warn("No inventory-skeleton was returned! Inventory won't work!")
+        return state
+      }
+
       const loginFolders = action.sessionInfo['inventory-skeleton'].reduce((all, folder) => {
         all.set(folder.folder_id, {
           name: folder.name,


### PR DESCRIPTION
Fixes #212.

Changes proposed in this pull request:

- Add save guards to optional fields in login to grid results.
  - `buddy-list` won't exist if the avatar doesn't have buddies.
  - `inventory-skeleton` might not exist.
