### PR TITLE
Form onSubmit

### DIFF
--- a/src/components/chatDialog.js
+++ b/src/components/chatDialog.js
@@ -38,7 +38,7 @@ export default function ChatDialog ({ isIM = false, data = [], names, sendTo, lo
       names={names}
       onScrolledTop={doLoadHistory}
     />
-    <div className={styles.InputRow}>
+    <form className={styles.InputRow} onSubmit={send}>
       <input
         type='text'
         className={styles.TextBox}
@@ -47,15 +47,8 @@ export default function ChatDialog ({ isIM = false, data = [], names, sendTo, lo
         aria-label={placeholderText}
         value={text}
         onChange={event => { setText(event.target.value) }}
-        onKeyDown={event => {
-          if (event.keyCode === 13) {
-            send(event)
-          }
-        }}
       />
-      <button className={styles.SendButton} onClick={send}>
-        send
-      </button>
-    </div>
+      <button className={styles.SendButton}>send</button>
+    </form>
   </div>
 }

--- a/src/components/chatDialog.test.js
+++ b/src/components/chatDialog.test.js
@@ -99,7 +99,7 @@ test('renders IM chat', () => {
       value: 'Hello World!'
     }
   })
-  sendButton.simulate('click')
+  sendButton.simulate('submit')
 
   expect(sendData.text).toBe('Hello World!')
   expect(sendData.count).toBe(1)

--- a/src/components/chatDialog.test.js
+++ b/src/components/chatDialog.test.js
@@ -47,7 +47,7 @@ test('renders local chat', () => {
       value: 'Hello World!'
     }
   })
-  sendButton.simulate('click')
+  sendButton.simulate('submit')
 
   expect(sendData.text).toBe('Hello World!')
   expect(sendData.count).toBe(1)

--- a/src/components/formElements.module.css
+++ b/src/components/formElements.module.css
@@ -56,6 +56,10 @@
 .SecondaryButton:hover, .SecondaryButton:focus {
   background: #868686;
 }
+.TransparentButton {
+  background: none;
+  border: none;
+}
 
 /* Input */
 

--- a/src/components/login/avatarLogin.js
+++ b/src/components/login/avatarLogin.js
@@ -33,7 +33,7 @@ export default function AvatarLogin ({ avatar, grid, isLoggingIn, onLogin, isSel
     </form>
   }
 
-  const onClick = event => {
+  const onSubmit = event => {
     event.preventDefault()
 
     if (password.length > 0) {
@@ -41,16 +41,10 @@ export default function AvatarLogin ({ avatar, grid, isLoggingIn, onLogin, isSel
     }
   }
 
-  const onKeyUp = event => {
-    if (event.keyCode === 13) {
-      onClick(event)
-    }
-  }
-
   const avatarName = new AvatarName(avatar.name).getDisplayName()
   const passwordInputId = `passwordFor${avatar.avatarIdentifier}`
 
-  return <form className={styles.AvatarLoginContainer}>
+  return <form className={styles.AvatarLoginContainer} onSubmit={onSubmit}>
     <h2 className={styles.Name}>{avatarName}</h2>
     <span className={styles.Grid}>@{grid.name}</span>
 
@@ -61,7 +55,6 @@ export default function AvatarLogin ({ avatar, grid, isLoggingIn, onLogin, isSel
       className={styles.PasswordInput}
       value={password}
       onChange={event => { setPassword(event.target.value) }}
-      onKeyUp={onKeyUp}
       required
       autoFocus
       disabled={isLoggingIn}
@@ -77,11 +70,7 @@ export default function AvatarLogin ({ avatar, grid, isLoggingIn, onLogin, isSel
       }}
     />
 
-    <button
-      className={styles.LoginButton}
-      onClick={onClick}
-      disabled={isLoggingIn || password.length === 0}
-    >
+    <button className={styles.LoginButton} disabled={isLoggingIn || password.length === 0}>
       {isLoggingIn === avatar.name ? 'Connecting ...' : 'Login'}
     </button>
   </form>

--- a/src/components/login/avatarLogin.js
+++ b/src/components/login/avatarLogin.js
@@ -11,25 +11,19 @@ export default function AvatarLogin ({ avatar, grid, isLoggingIn, onLogin, isSel
   }, [isSelected])
 
   if (!isSelected) {
-    const onSetActive = event => {
-      event.preventDefault()
-      onSelect(avatar.avatarIdentifier)
-    }
-
     return <form
       className={`${styles.AvatarLoginContainer} ${styles['not-selected']}`}
-      onClick={onSetActive}
-      onKeyUp={event => {
-        if (event.keyCode === 13) {
-          onSetActive(event)
-        }
+      onSubmit={event => {
+        event.preventDefault()
+        onSelect(avatar.avatarIdentifier)
       }}
-      tabIndex='0'
     >
-      <span className={styles.Name}>{new AvatarName(avatar.name).getDisplayName()}</span>
-      <span className={styles.Grid}>@{grid.name}</span>
+      <button className={styles.HiddenButton}>
+        <span className={styles.Name}>{new AvatarName(avatar.name).getDisplayName()}</span>
+        <span className={styles.Grid}>@{grid.name}</span>
 
-      <span className={styles.ActiveText}>click to login</span>
+        <span className={styles.ActiveText}>click to login</span>
+      </button>
     </form>
   }
 

--- a/src/components/login/avatarLogin.module.css
+++ b/src/components/login/avatarLogin.module.css
@@ -17,14 +17,30 @@
   box-shadow: 0.2em 0.2em 0.4em 0.1em black;
 }
 .Container.not-selected {
-  cursor: pointer;
   background-color: rgb(95, 95, 95);
   background-color: var(--dialog-background);
   color: var(--dialog-color);
   box-shadow: 0.1em 0.1em 0.3em 0px black;
+  border: 2px solid rgb(95, 95, 95);
+  border: 2px solid var(--dialog-background);
 }
-.Container.not-selected:focus {
-  border: 2px solid highlight;
+.Container.not-selected:focus-within {
+  border-color: highlight;
+  outline: none;
+}
+.Container.not-selected:hover {
+  box-shadow: 0.2em 0.2em 0.6em 0em black;
+}
+
+.HiddenButton {
+  display: flex;
+  flex-direction: column;
+  background: none;
+  border: none;
+  color: var(--dialog-color);
+}
+.HiddenButton:focus {
+  border: none;
   outline: none;
 }
 
@@ -48,7 +64,7 @@
 }
 
 @supports (display: grid) {
-  .AvatarLoginContainer {
+  .AvatarLoginContainer, .HiddenButton {
     display: grid;
     grid-template-areas:
       "name name grid-name"
@@ -85,6 +101,10 @@
   .NewAvatarLoginContainer > span,
   .NewAvatarLoginContainer > div {
     margin-top: 0em;
+  }
+
+  .AvatarLoginContainer.not-selected, .NewAvatarLoginContainer.not-selected {
+    display: flex;
   }
 }
 
@@ -143,6 +163,9 @@
   text-align: center;
   white-space: nowrap;
   font-size: 120%;
+}
+.not-selected .Title {
+  grid-area: name;
 }
 
 @media (max-width: 450px) {

--- a/src/components/login/avatarLogin.test.js
+++ b/src/components/login/avatarLogin.test.js
@@ -60,9 +60,7 @@ test('login works', () => {
   const input = rendered.find('input')
   const button = rendered.find('button')
 
-  input.simulate('keyUp', {
-    keyCode: 13
-  })
+  input.simulate('submit')
 
   // no password
   expect(button.prop('disabled')).toBeTruthy()
@@ -74,7 +72,7 @@ test('login works', () => {
     }
   })
 
-  button.simulate('click')
+  button.simulate('submit')
 
   expect(loginInfo.count).toBe(1)
   expect(loginInfo.avatar).toBe(avatar)
@@ -83,9 +81,7 @@ test('login works', () => {
   loginInfo.avatar = null
   loginInfo.password = null
 
-  input.simulate('keyUp', {
-    keyCode: 13
-  })
+  input.simulate('submit')
 
   expect(loginInfo.count).toBe(2)
   expect(loginInfo.avatar).toBe(avatar)

--- a/src/components/login/newAvatarLogin.js
+++ b/src/components/login/newAvatarLogin.js
@@ -29,24 +29,18 @@ export default function NewAvatarLogin ({
   const [isGridLLSD, setIsGridLLSD] = useState(true)
 
   if (!isSelected) {
-    const onSetActive = event => {
-      event.preventDefault()
-      onSelect('new')
-    }
-
     return <form
       className={`${styles.NewAvatarLoginContainer} ${styles['not-selected']}`}
-      onClick={onSetActive}
-      onKeyUp={event => {
-        if (event.keyCode === 13) {
-          onSetActive(event)
-        }
+      onSubmit={event => {
+        event.preventDefault()
+        onSelect('new')
       }}
-      tabIndex='0'
     >
-      <h2 className={styles.Title}>Add avatar or login anonymously</h2>
+      <button className={styles.HiddenButton}>
+        <h2 className={styles.Title}>Add avatar or login anonymously</h2>
 
-      <span className={styles.ActiveText}>click to add</span>
+        <span className={styles.ActiveText}>click to add</span>
+      </button>
     </form>
   }
 

--- a/src/components/login/newAvatarLogin.js
+++ b/src/components/login/newAvatarLogin.js
@@ -57,9 +57,7 @@ export default function NewAvatarLogin ({
   const isValid = isNameValid && name.length > 1 && isPwValid && gridIsValid
 
   const doLogin = event => {
-    if (event && event.preventDefault) {
-      event.preventDefault()
-    }
+    event.preventDefault()
 
     if (!isValid) return
 
@@ -75,13 +73,10 @@ export default function NewAvatarLogin ({
     onLogin(name, password, grid, save)
   }
 
-  const onKeyUp = event => {
-    if (event.keyCode === 13) {
-      doLogin(event)
-    }
-  }
-
-  return <form className={styles.NewAvatarLoginContainer + (isNewGrid ? ' ' + styles.high : '')}>
+  return <form
+    className={styles.NewAvatarLoginContainer + (isNewGrid ? ' ' + styles.high : '')}
+    onSubmit={doLogin}
+  >
     <h2 className={styles.Title}>
       {isSignedIn ? 'Add avatar or ' : ''}
       login anonymously
@@ -94,7 +89,6 @@ export default function NewAvatarLogin ({
       className={styles.NewNameInput}
       value={name}
       onChange={onNameChange}
-      onKeyUp={onKeyUp}
       disabled={isLoggingIn}
       minLength='1'
       required
@@ -117,7 +111,6 @@ export default function NewAvatarLogin ({
       className={styles.PasswordInput}
       value={password}
       onChange={onPasswordChange}
-      onKeyUp={onKeyUp}
       disabled={isLoggingIn}
       minLength='2'
       required
@@ -148,7 +141,6 @@ export default function NewAvatarLogin ({
           className={formElementsStyles.Input}
           value={gridName}
           onChange={onGridNameChange}
-          onKeyUp={onKeyUp}
           minLength='1'
           required
         />
@@ -162,7 +154,6 @@ export default function NewAvatarLogin ({
           placeholder='https://example.com/login'
           value={gridUrl}
           onChange={onGridUrlChange}
-          onKeyUp={onKeyUp}
           required
         />
       </div>
@@ -201,7 +192,6 @@ export default function NewAvatarLogin ({
     <button
       id='newAvatarLoginButton'
       className={styles.LoginButton}
-      onClick={doLogin}
       disabled={isLoggingIn || !isValid}
     >
       {isLoggingIn === name ? 'Connecting ...' : 'Login'}

--- a/src/components/login/newAvatarLogin.test.js
+++ b/src/components/login/newAvatarLogin.test.js
@@ -79,7 +79,7 @@ test('not signed in login works', () => {
   })
 
   rendered.update()
-  loginButton.simulate('click')
+  loginButton.simulate('submit')
 
   expect(loginData.length).toBe(1)
   expect(loginData[0]).toEqual({
@@ -92,13 +92,9 @@ test('not signed in login works', () => {
   expect(saveCheckbox.prop('disabled')).toBe(true)
   expect(saveCheckbox.prop('checked')).toBe(false)
 
-  nameInput.simulate('keyUp', {
-    keyCode: 13
-  })
+  nameInput.simulate('submit')
 
-  passwordInput.simulate('keyUp', {
-    keyCode: 13
-  })
+  passwordInput.simulate('submit')
 
   expect(loginData.length).toBe(3)
   expect(loginData[1]).toEqual({
@@ -168,7 +164,7 @@ test('signed in login works', () => {
   })
 
   rendered.update()
-  loginButton.simulate('click')
+  loginButton.simulate('submit')
 
   expect(loginData.length).toBe(1)
   expect(loginData[0]).toEqual({
@@ -185,13 +181,9 @@ test('signed in login works', () => {
     }
   })
 
-  nameInput.simulate('keyUp', {
-    keyCode: 13
-  })
+  nameInput.simulate('submit')
 
-  passwordInput.simulate('keyUp', {
-    keyCode: 13
-  })
+  passwordInput.simulate('submit')
 
   expect(loginData.length).toBe(3)
   expect(loginData[1]).toEqual({
@@ -296,7 +288,7 @@ test('adding new grid', () => {
     }
   })
 
-  loginButton.simulate('click')
+  loginButton.simulate('submit')
 
   expect(loginData.length).toBe(1)
   expect(loginData[0]).toEqual({
@@ -317,7 +309,7 @@ test('adding new grid', () => {
     }
   })
   rendered.update()
-  loginButton.simulate('click')
+  loginButton.simulate('submit')
 
   expect(loginData.length).toBe(2)
   expect(loginData[1]).toEqual({

--- a/src/components/popups/resetPasswordDialog.js
+++ b/src/components/popups/resetPasswordDialog.js
@@ -19,94 +19,106 @@ export default function ResetPasswordDialog ({ type, onChangePassword, onSignOut
     password1.length >= 8 &&
     password1 === password2
 
+  const onSubmit = event => {
+    event.preventDefault()
+
+    if (canChange) {
+      setIsChanging(true)
+      setErrorMessage(null)
+
+      onChangePassword(resetKey, password1)
+        .catch(err => {
+          setErrorMessage(err.reason || err.toString())
+          setIsChanging(false)
+        })
+    }
+  }
+
   return <Popup title='Reset password' onClose={onCancel}>
-    <div className={formStyles.FormField}>
-      <label htmlFor='oldInput'>{isEncryption ? 'Reset-key' : 'Password'}:</label>
-      <input
-        id='oldInput'
-        type='text'
-        className={formStyles.Input}
-        value={resetKey}
-        onChange={event => { setResetKey(event.target.value) }}
-        autoFocus
-        required
-        disabled={isChanging}
-      />
-      <small id='helpOld' className={formStyles.Help}>Please enter one of your reset-keys</small>
-      <small
-        id='oldInputError'
-        className={formStyles.Error}
-        data-hide={errorMessage == null || errorMessage.length === 0}
-        role='alert'
-      >
-        {errorMessage}
-      </small>
-    </div>
+    <form onSubmit={onSubmit}>
+      <div className={formStyles.FormField}>
+        <label htmlFor='oldInput'>{isEncryption ? 'Reset-key' : 'Password'}:</label>
+        <input
+          id='oldInput'
+          type='text'
+          className={formStyles.Input}
+          value={resetKey}
+          onChange={event => { setResetKey(event.target.value) }}
+          autoFocus
+          required
+          disabled={isChanging}
+        />
+        <small id='helpOld' className={formStyles.Help}>Please enter one of your reset-keys</small>
+        <small
+          id='oldInputError'
+          className={formStyles.Error}
+          data-hide={errorMessage == null || errorMessage.length === 0}
+          role='alert'
+        >
+          {errorMessage}
+        </small>
+      </div>
 
-    <div className={formStyles.FormField}>
-      <label htmlFor='newPassword'>New {isEncryption ? 'encryption ' : ''}Password</label>
-      <input
-        id='newPassword'
-        type='password'
-        className={formStyles.Input}
-        value={password1}
-        onChange={event => { setPassword1(event.target.value) }}
-        required
-        aria-describedby='newPasswordHelp'
-        disabled={isChanging}
-      />
-      <small id='newPasswordHelp' className={formStyles.Help}>Minimal length: 8 characters!</small>
-    </div>
+      <div className={formStyles.FormField}>
+        <label htmlFor='newPassword'>New {isEncryption ? 'encryption ' : ''}Password</label>
+        <input
+          id='newPassword'
+          type='password'
+          className={formStyles.Input}
+          value={password1}
+          onChange={event => { setPassword1(event.target.value) }}
+          required
+          aria-describedby='newPasswordHelp'
+          disabled={isChanging}
+        />
+        <small id='newPasswordHelp' className={formStyles.Help}>Minimal length: 8 characters!</small>
+      </div>
 
-    <div className={formStyles.FormField}>
-      <label htmlFor='newPassword2'>Repeat new password</label>
-      <input
-        id='newPassword2'
-        type='password'
-        className={formStyles.Input}
-        value={password2}
-        onChange={event => { setPassword2(event.target.value) }}
-        required
-        aria-describedby='secondPwInputError'
-        disabled={isChanging}
-      />
-      <small
-        id='secondPwInputError'
-        className={formStyles.Error}
-        data-hide={password2.length === 0 || password1 === password2}
-        role='alert'
-      >
-        Password doesn't match!
-      </small>
-    </div>
+      <div className={formStyles.FormField}>
+        <label htmlFor='newPassword2'>Repeat new password</label>
+        <input
+          id='newPassword2'
+          type='password'
+          className={formStyles.Input}
+          value={password2}
+          onChange={event => { setPassword2(event.target.value) }}
+          required
+          aria-describedby='secondPwInputError'
+          disabled={isChanging}
+        />
+        <small
+          id='secondPwInputError'
+          className={formStyles.Error}
+          data-hide={password2.length === 0 || password1 === password2}
+          role='alert'
+        >
+          Password doesn't match!
+        </small>
+      </div>
 
-    <div className={styles.ButtonsRow}>
-      <button className={formStyles.SecondaryButton} onClick={onCancel} disabled={isChanging}>
-        cancel
-      </button>
-      <button className={formStyles.DangerButton} onClick={onSignOut} disabled={isChanging}>
-        sign out
-      </button>
-    </div>
-    <div className={styles.ButtonsRow}>
-      <button
-        className={formStyles.PrimaryButton}
-        onClick={() => {
-          if (canChange) {
-            setIsChanging(true)
-            setErrorMessage(null)
-
-            onChangePassword(resetKey, password1)
-              .catch(err => {
-                setErrorMessage(err.reason || err.toString())
-                setIsChanging(false)
-              })
-          }
-        }}
-        disabled={!canChange}
-      >
-        change {isEncryption ? 'encryption ' : ''}password
-      </button>
-    </div>
+      <div className={styles.ButtonsRow}>
+        <button
+          type='button'
+          className={formStyles.SecondaryButton}
+          onClick={onCancel}
+          disabled={isChanging}
+        >
+          cancel
+        </button>
+        <button
+          type='button'
+          className={formStyles.DangerButton}
+          onClick={onSignOut}
+          disabled={isChanging}
+        >
+          sign out
+        </button>
+      </div>
+      <div className={styles.ButtonsRow}>
+        <button className={formStyles.PrimaryButton} disabled={!canChange}>
+          change {isEncryption ? 'encryption ' : ''}password
+        </button>
+      </div>
+    </form>
   </Popup>
 }

--- a/src/components/popups/resetPasswordDialog.test.js
+++ b/src/components/popups/resetPasswordDialog.test.js
@@ -115,7 +115,7 @@ test('should call onChangePassword only if the input is valid', () => {
   updateInputs('2309ab6d30b8f201cd20fa9edead0b20', 'password', 'password')
   expect(getChangePwButton().prop('disabled')).toBe(false)
 
-  getChangePwButton().simulate('click')
+  getChangePwButton().simulate('submit')
   expect(cancelCount).toBe(0)
   expect(signOutCount).toBe(0)
   expect(changePwCount).toBe(1)

--- a/src/components/popups/signInPopup.js
+++ b/src/components/popups/signInPopup.js
@@ -49,14 +49,8 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
       })
   }
 
-  const onKeyPress = event => {
-    if (event.key === 'Enter') {
-      send(event)
-    }
-  }
-
   return <Popup title={isSignUp ? 'Sign up' : 'Sign in'} onClose={onCancel}>
-    <form className={styles.Container}>
+    <form className={styles.Container} onSubmit={send}>
       <div className={formStyles.FormField}>
         <label htmlFor='username'>
           Username / email:
@@ -71,7 +65,6 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
             setUsername(event.target.value)
             setUsernameValid(event.target.validity.valid)
           }}
-          onKeyPress={onKeyPress}
           placeholder='me-avatar@example.com'
           autoFocus
           required
@@ -94,7 +87,6 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
           type='password'
           className={formStyles.Input}
           autoComplete={isSignUp ? 'new-password' : 'current-password'}
-          onKeyPress={onKeyPress}
           required
           minLength='8'
           aria-describedby={isSignUp && 'passwordHelp'}
@@ -126,7 +118,6 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
           type='password'
           className={formStyles.Input}
           autoComplete='new-password'
-          onKeyPress={onKeyPress}
           required
           minLength='8'
           disabled={isSigningIn}
@@ -150,7 +141,6 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
           id='cryptoPassword'
           type='password'
           className={formStyles.Input}
-          onKeyPress={onKeyPress}
           required
           minLength='8'
           aria-describedby={isSignUp && 'cryptoPwHelp'}
@@ -177,7 +167,6 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
           id='cryptoPassword2'
           type='password'
           className={formStyles.Input}
-          onKeyPress={onKeyPress}
           required
           minLength='8'
           disabled={isSigningIn}
@@ -198,6 +187,7 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
 
       <div className={styles.ButtonsContainer}>
         <button
+          type='button'
           className={formStyles.SecondaryButton}
           onClick={onCancel}
           disabled={isSigningIn}
@@ -207,7 +197,6 @@ export default function SignInPopup ({ isSignUp, onSend, onCancel }) {
         </button>
         <button
           className={formStyles.OkButton}
-          onClick={send}
           disabled={!isValid || isSigningIn}
           onFocus={onFocusScrollIntoView}
         >

--- a/src/components/popups/signInPopup.test.js
+++ b/src/components/popups/signInPopup.test.js
@@ -119,7 +119,7 @@ test('click actions', async () => {
     }
 
     shouldCallSend = true
-    popup.find('button').last().simulate('click')
+    popup.find('button').last().simulate('submit')
 
     popup.update()
 

--- a/src/components/popups/unlockDialog.js
+++ b/src/components/popups/unlockDialog.js
@@ -12,9 +12,7 @@ export default function UnlockDialog ({ onUnlock, onSignOut, onForgottenPassword
   const [errorText, setErrorText] = useState(null)
 
   const unlock = async event => {
-    if (event && typeof event.preventDefault === 'function') {
-      event.preventDefault()
-    }
+    event.preventDefault()
 
     if (password.length === 0) {
       setErrorText('No password was entered jet!')
@@ -48,7 +46,7 @@ export default function UnlockDialog ({ onUnlock, onSignOut, onForgottenPassword
   </span>
 
   return <Popup title={title}>
-    <form className={styles.Content}>
+    <form className={styles.Content} onSubmit={unlock}>
       <span>Please enter your <i>Encryption-Password</i> to unlock this app!</span>
 
       <div className={styles.PasswordRow}>
@@ -62,19 +60,18 @@ export default function UnlockDialog ({ onUnlock, onSignOut, onForgottenPassword
           disabled={isUnlocking}
           value={password}
           onChange={event => { setPassword(event.target.value) }}
-          onKeyDown={event => {
-            if (event.keyCode === 13) {
-              unlock()
-            }
-          }}
           aria-describedby='resetPassword'
         />
         <small id='resetPassword' className={formStyles.Help}>
           If you did forget your encryption-password?
           <button
             id='resetPasswordButton'
+            type='button'
             className={styles.ResetButton}
-            onClick={() => { onForgottenPassword('encryption') }}
+            onClick={event => {
+              event.preventDefault()
+              onForgottenPassword('encryption')
+            }}
           >
             Reset password
           </button>
@@ -92,15 +89,18 @@ export default function UnlockDialog ({ onUnlock, onSignOut, onForgottenPassword
         <button
           id='unlockButton'
           className={formStyles.PrimaryButton}
-          onClick={unlock}
           disabled={isUnlocking}
         >
           Unlock
         </button>
         <button
           id='signOutButton'
+          type='button'
           className={formStyles.DangerButton}
-          onClick={onSignOut}
+          onClick={event => {
+            event.preventDefault()
+            onSignOut()
+          }}
           disabled={isUnlocking}
         >
           Sign out

--- a/src/components/popups/unlockDialog.test.js
+++ b/src/components/popups/unlockDialog.test.js
@@ -51,9 +51,7 @@ test('unlock with return key', () => {
     'If you did forget your encryption-password?Reset password'
   )
 
-  pwInput.simulate('keyDown', {
-    keyCode: 13
-  })
+  pwInput.simulate('submit')
   expect(unlockEvents.count).toBe(0) // empty input doesn't unlock
   expect(rendered.find('small').at(1).text()).toBe('No password was entered jet!')
 
@@ -63,9 +61,7 @@ test('unlock with return key', () => {
     }
   })
 
-  pwInput.simulate('keyDown', {
-    keyCode: 13
-  })
+  pwInput.simulate('submit')
   expect(unlockEvents).toEqual({
     count: 1,
     lastPassword: 'aPassword',
@@ -117,7 +113,7 @@ test('unlock with button', () => {
     'If you did forget your encryption-password?Reset password'
   )
 
-  unlockButton.simulate('click')
+  unlockButton.simulate('submit')
   expect(unlockEvents.count).toBe(0) // empty input doesn't unlock
   expect(rendered.find('small').at(1).text()).toBe('No password was entered jet!')
 
@@ -126,7 +122,7 @@ test('unlock with button', () => {
       value: 'aPassword'
     }
   })
-  unlockButton.simulate('click')
+  unlockButton.simulate('submit')
   expect(unlockEvents).toEqual({
     count: 1,
     lastPassword: 'aPassword',


### PR DESCRIPTION
Browsers already handle all types of enter and submit with the `submit` event on `<form>`.
This pull request changes all inputs to use `<form>`.

This will make it more accessible.

Changes proposed in this pull request:

- Move all inputs into an `<form>`.
- Use `onSubmit` where `<form>` is used.
- Use a `<button>` for focusing a not active avatar login form.

Reviewer: @Terreii
