### PR TITLE
Use box-shadow for focus outline

### DIFF
--- a/src/components/formElements.module.css
+++ b/src/components/formElements.module.css
@@ -19,6 +19,9 @@
   box-shadow: 0px 0px 0px 3px highlight;
   outline: none;
 }
+.Button:active {
+  background: #aeb0b3;
+}
 .Button:disabled {
   opacity: 0.65;
 }
@@ -31,6 +34,9 @@
 .DangerButton:hover, .DangerButton:focus {
   background: #c82333;
 }
+.DangerButton:active {
+  background: #b72332;
+}
 
 .OkButton {
   composes: Button;
@@ -39,6 +45,9 @@
 }
 .OkButton:hover, .OkButton:focus {
   background: #218838;
+}
+.OkButton:active {
+  background: #1f8235;
 }
 
 .PrimaryButton {
@@ -49,6 +58,9 @@
 .PrimaryButton:hover, .PrimaryButton:focus {
   background: #0c5a93;
 }
+.PrimaryButton:active {
+  background: #04497b;
+}
 
 .SecondaryButton {
   composes: Button;
@@ -57,6 +69,10 @@
 .SecondaryButton:hover, .SecondaryButton:focus {
   background: #868686;
 }
+.SecondaryButton:active {
+  background: #777676;
+}
+
 .TransparentButton {
   background: none;
   border: none;

--- a/src/components/formElements.module.css
+++ b/src/components/formElements.module.css
@@ -16,7 +16,8 @@
 }
 .Button:hover, .Button:focus {
   background: #cacbcd;
-  outline-color: highlight;
+  box-shadow: 0px 0px 0px 3px highlight;
+  outline: none;
 }
 .Button:disabled {
   opacity: 0.65;
@@ -72,7 +73,7 @@
   color: rgba(0, 0, 0, 0.87);
 }
 .Input:focus {
-  box-shadow: 0px 0px 1px 2px highlight;
+  box-shadow: 0px 0px 0px 3px highlight;
   outline: none;
 }
 .Input:invalid {

--- a/src/components/popups/unlockAndSignOut.module.css
+++ b/src/components/popups/unlockAndSignOut.module.css
@@ -24,7 +24,7 @@
   flex-direction: row-reverse;
   justify-content: space-between;
   margin-top: .7em;
-  padding: .25em 0em;
+  padding: .25em 0.2em;
 }
 .ButtonsRow > button + button {
   margin-right: 2.75em;


### PR DESCRIPTION
Changes proposed in this pull request:

- Use a box-shadow for an outline on buttons and inputs
- Remove outline from buttons and inputs
