### PR TITLE
find URLs after a )

### DIFF
--- a/src/components/text.js
+++ b/src/components/text.js
@@ -12,7 +12,19 @@ import anchorme from 'anchorme'
 export default function Text ({ text, multiline, className }) {
   const parsed = useMemo(
     () => {
-      const urls = anchorme(text, { list: true })
+      const found = anchorme(text.replace(/\)/g, '.)escape'), { list: true })
+
+      const urls = found.map(url => {
+        if (/\.\)escape/g.test(url.raw)) {
+          return {
+            ...url,
+            raw: url.raw.replace(/\.\)escape/g, ')'),
+            encoded: url.encoded.replace(/\.\)escape/g, ')')
+          }
+        } else {
+          return url
+        }
+      })
 
       if (urls.length === 0) {
         return [

--- a/src/components/text.test.js
+++ b/src/components/text.test.js
@@ -37,7 +37,7 @@ it('should render plain URLs after a firefox chat info', () => {
     <div>
       <Text
         text={'(32W 6.3.2f*) http://wiki.secondlife.com/wiki/Main_Page ' +
-        'https://en.wikipedia.org/wiki/Second_Life'}
+        'https://en.wikipedia.org/wiki/Second_Life http://example.com/test()'}
       />
     </div>
   )
@@ -55,6 +55,11 @@ it('should render plain URLs after a firefox chat info', () => {
     .toBe('https://en.wikipedia.org/wiki/Second_Life')
   expect(queryByText('https://en.wikipedia.org/wiki/Second_Life').rel)
     .toBe('noopener noreferrer')
+
+  expect(queryByText('http://example.com/test()')).toBeTruthy()
+  expect(queryByText('http://example.com/test()').tagName).toBe('A')
+  expect(queryByText('http://example.com/test()').href).toBe('http://example.com/test()')
+  expect(queryByText('http://example.com/test()').rel).toBe('noopener noreferrer')
 })
 
 it('should render formatted URLs as <a> with the text as its child', () => {

--- a/src/components/text.test.js
+++ b/src/components/text.test.js
@@ -32,6 +32,31 @@ it('should render plain URLs as <a>', () => {
     .toBe('noopener noreferrer')
 })
 
+it('should render plain URLs after a firefox chat info', () => {
+  const { queryByText } = render(
+    <div>
+      <Text
+        text={'(32W 6.3.2f*) http://wiki.secondlife.com/wiki/Main_Page ' +
+        'https://en.wikipedia.org/wiki/Second_Life'}
+      />
+    </div>
+  )
+
+  expect(queryByText('http://wiki.secondlife.com/wiki/Main_Page')).toBeTruthy()
+  expect(queryByText('http://wiki.secondlife.com/wiki/Main_Page').tagName).toBe('A')
+  expect(queryByText('http://wiki.secondlife.com/wiki/Main_Page').href)
+    .toBe('http://wiki.secondlife.com/wiki/Main_Page')
+  expect(queryByText('http://wiki.secondlife.com/wiki/Main_Page').rel)
+    .toBe('noopener noreferrer')
+
+  expect(queryByText('https://en.wikipedia.org/wiki/Second_Life')).toBeTruthy()
+  expect(queryByText('https://en.wikipedia.org/wiki/Second_Life').tagName).toBe('A')
+  expect(queryByText('https://en.wikipedia.org/wiki/Second_Life').href)
+    .toBe('https://en.wikipedia.org/wiki/Second_Life')
+  expect(queryByText('https://en.wikipedia.org/wiki/Second_Life').rel)
+    .toBe('noopener noreferrer')
+})
+
 it('should render formatted URLs as <a> with the text as its child', () => {
   const { queryByText } = render(
     <div>


### PR DESCRIPTION
*The problem*
URLs that are send after a `)` are not found.

Changes proposed in this pull request:

- Escape `)` in text and find URLs. Then de-escape `)` on found URLs.

Reviewer: @Terreii
