### PR TITLE
Handle UDP disconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16846,6 +16846,11 @@
         "brorand": "^1.0.1"
       }
     },
+    "milliseconds": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/milliseconds/-/milliseconds-1.0.3.tgz",
+      "integrity": "sha1-H/Q3xPc0sTjvfCztuk2IgMf1wtg="
+    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@hapi/boom": "^9.1.0",
     "hoodie": "^28.2.10",
     "hoodie-plugin-store-crypto": "^3.2.1",
+    "milliseconds": "^1.0.3",
     "node-fetch": "^2.6.0",
     "uuid": "^7.0.2",
     "ws": "^7.2.3",

--- a/src/actions/connectCircuit.js
+++ b/src/actions/connectCircuit.js
@@ -1,10 +1,14 @@
 import createCallback from './simAction'
+import { userWasKicked } from '../bundles/session'
 
 // Starts listening to packets on the circuit and dispatch a parsed action.
 export default function init () {
   return (dispatch, getState, { circuit }) => {
     let callback = createCallback(dispatch)
     circuit.on('packetReceived', callback)
+
+    let closeHandler = getCloseHandler(dispatch)
+    circuit.on('close', closeHandler)
 
     if (process.env.NODE_ENV !== 'production') {
       if (module.hot) {
@@ -14,7 +18,31 @@ export default function init () {
           callback = createCallback(dispatch)
           circuit.on('packetReceived', callback)
         })
+
+        module.hot.accept('../bundles/session', () => {
+          circuit.removeListener('close', closeHandler)
+          closeHandler = getCloseHandler(dispatch)
+          circuit.on('close', closeHandler)
+        })
       }
     }
+  }
+}
+
+function getCloseHandler (dispatch) {
+  const disconnectMessage = 'You have been disconnected!\n\n' +
+    'Please check if you have an Internet connection.\n' +
+    'This problem could also be on our or the grids side.'
+
+  const reasonTexts = {
+    'UDP disconnect': disconnectMessage,
+    'Max reconnection tries': disconnectMessage
+  }
+
+  return event => {
+    const reason = event.reason in reasonTexts
+      ? reasonTexts[event.reason]
+      : event.reason
+    dispatch(userWasKicked({ reason }))
   }
 }

--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import ms from 'milliseconds'
 import { v4 as uuid } from 'uuid'
 
 import { viewerName, viewerVersion, viewerPlatform, viewerPlatformVersion } from '../viewerInfo'
@@ -242,13 +243,20 @@ export function logout () {
 
       dispatch(startLogout())
 
-      circuit.once('LogoutReply', msg => {
+      let isLoggedOut = false
+      const logoutHandler = msg => {
+        if (isLoggedOut) return
+
+        isLoggedOut = true
         dispatch(afterAvatarSessionEnds())
 
         dispatch(didLogout())
 
         resolve()
-      })
+      }
+
+      circuit.once('LogoutReply', logoutHandler)
+      setTimeout(logoutHandler, ms.seconds(30)) // timeout for LogoutReply
     })
   }
 }

--- a/src/network/circuit.js
+++ b/src/network/circuit.js
@@ -338,7 +338,7 @@ export default class Circuit extends events.EventEmitter {
 
       this.lastReceivedCount += 1
 
-      if (this.lastReceivedCount > 1.050) {
+      if (this.lastReceivedCount > 1050) {
         this.emit('close', {
           code: 1006,
           reason: 'UDP disconnect'

--- a/src/network/circuit.js
+++ b/src/network/circuit.js
@@ -7,7 +7,7 @@
  */
 
 import events from 'events'
-import Deque from 'double-ended-queue'
+import Queue from 'double-ended-queue'
 
 import { parseBody, createBody } from './networkMessages'
 import { getValueOf, mapBlockOf } from './msgGetters'
@@ -23,6 +23,11 @@ export default class Circuit extends events.EventEmitter {
    * This is the sequenceNumber from the server.
    */
   senderSequenceNumber = 0
+
+  /**
+   * The WebSocket that connects to the Server
+   */
+  websocket = null
 
   /**
    * Did all handshaking happen?
@@ -44,13 +49,18 @@ export default class Circuit extends events.EventEmitter {
   /**
    * Que of Acks that should be send on the end of an package.
    */
-  simAcksOnPacket = new Deque()
+  simAcksOnPacket = new Queue()
 
   /**
    * Acks of packages send from the viewer.
    * It also includes their body and other infos, needed to resend them.
    */
   viewerAcks = []
+
+  /**
+   * How often the circuit did try to reconnect.
+   */
+  reconnectCount = 0
 
   /**
    * Connects to the Sim using the UDP-Bridge of the Andromeda Viewer Server.
@@ -67,16 +77,21 @@ export default class Circuit extends events.EventEmitter {
     this.circuitCode = circuitCode
     this.sessionId = sessionId
 
-    const socketUrl = new window.URL(window.location.href.replace(/#.*$/, ''))
+    this._createNewWebSocket()
+
+    this.acksProcessInterval = setTimeout(() => this._startAcksProcess(), 100)
+  }
+
+  _createNewWebSocket () {
+    const socketUrl = new URL('/andromeda-bridge', window.location)
     // http -> ws  &  https -> wss
     socketUrl.protocol = socketUrl.protocol.replace(/^http/, 'ws')
-    socketUrl.pathname = '/andromeda-bridge'
+
     this.websocket = new window.WebSocket(socketUrl.toString())
     this.websocket.binaryType = 'arraybuffer'
     this.websocket.onopen = this._onOpen.bind(this)
     this.websocket.onmessage = this._onMessage.bind(this)
-
-    setTimeout(() => this._startAcksProcess(), 100)
+    this.websocket.onclose = this._onWebSocketClose.bind(this)
   }
 
   /**
@@ -85,6 +100,45 @@ export default class Circuit extends events.EventEmitter {
    */
   _onOpen () {
     this.websocket.send(this.sessionId)
+  }
+
+  /**
+   * Called when the WebSocked did close.
+   * @param {CloseEvent} event CloseEvent from the websocket
+   */
+  _onWebSocketClose (event) {
+    this.websocketIsOpen = false
+
+    if (event.code === 1000) {
+      // Normal session end
+      return
+    }
+
+    if (event.code === 1008) {
+      this.emit('close', {
+        code: event.code,
+        reason: event.reason
+      })
+      this.removeAllListeners()
+      clearInterval(this.acksProcessInterval)
+      return
+    }
+
+    if (this.reconnectCount > 10) {
+      this.emit('close', {
+        code: 1006,
+        reason: 'Max reconnection tries'
+      })
+      this.removeAllListeners()
+      clearInterval(this.acksProcessInterval)
+      return
+    }
+
+    setTimeout(
+      this._createNewWebSocket.bind(this),
+      100 << this.reconnectCount
+    )
+    this.reconnectCount += 1
   }
 
   close () {
@@ -217,10 +271,8 @@ export default class Circuit extends events.EventEmitter {
 
     const sequenceNumber = this.sequenceNumber
     header.writeUInt32BE(sequenceNumber, 1)
-    this.sequenceNumber++
-    if (this.sequenceNumber > 4294967295) {
-      this.sequenceNumber = 0
-    }
+    // counts up until 4294967295 and then goes back to 0
+    this.sequenceNumber = (sequenceNumber + 1) % 4294967296
 
     const packet = Buffer.concat([target, header, body, acks])
 
@@ -274,6 +326,8 @@ export default class Circuit extends events.EventEmitter {
   _startAcksProcess () {
     let pingId = 0
     this.acksProcessInterval = setInterval(() => {
+      if (!this.websocketIsOpen) return
+
       this._sendAcks()
 
       if (this.viewerAcks.length > 0) {
@@ -288,7 +342,7 @@ export default class Circuit extends events.EventEmitter {
           }
         ]
       })
-      pingId = pingId === 255 ? 0 : pingId + 1
+      pingId = (pingId + 1) % 256 // counts up until 255 and then goes back to 0
     }, 100)
   }
 

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -840,11 +840,13 @@ describe('disconnection', () => {
     circuit = new Circuit('127.0.0.1', 8080, 123456, 'session id')
     openSocket()
 
+    jest.runOnlyPendingTimers()
+
     const closeHandler = jest.fn()
     circuit.on('close', closeHandler)
 
     // Timeout after 1 minute and 45 seconds
-    jest.runTimersToTime((60 + 45) * 1000 + 5)
+    jest.runTimersToTime((60 + 45) * 1000 + 150)
 
     expect(closeHandler).toHaveBeenCalledWith({
       code: 1006,

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+import ms from 'milliseconds'
+
 import Circuit from './circuit'
 
 import { createBody, parseBody } from './networkMessages'
@@ -845,8 +847,7 @@ describe('disconnection', () => {
     const closeHandler = jest.fn()
     circuit.on('close', closeHandler)
 
-    // Timeout after 1 minute and 45 seconds
-    jest.runTimersToTime((60 + 45) * 1000 + 150)
+    jest.runTimersToTime(ms.minutes(1) + ms.seconds(45) + 150)
 
     expect(closeHandler).toHaveBeenCalledWith({
       code: 1006,

--- a/src/network/circuit.test.js
+++ b/src/network/circuit.test.js
@@ -403,6 +403,7 @@ test('Acks are send 2 times with the PacketAck message', () => {
 
   for (let i = 0; i < 3; ++i) {
     jest.runOnlyPendingTimers()
+    circuit.websocket.onmessage({ data: createTestMessage() })
   }
 
   const acks = circuit.websocket.send.mock.calls
@@ -831,6 +832,23 @@ describe('disconnection', () => {
     expect(closeEvent).toHaveBeenCalledWith({
       code: 1006,
       reason: 'Max reconnection tries'
+    })
+  })
+
+  // This is for developing and if there will be a direct UDP connection in the future
+  test('it should disconnect after a timeout of not receiving any messages', () => {
+    circuit = new Circuit('127.0.0.1', 8080, 123456, 'session id')
+    openSocket()
+
+    const closeHandler = jest.fn()
+    circuit.on('close', closeHandler)
+
+    // Timeout after 1 minute and 45 seconds
+    jest.runTimersToTime((60 + 45) * 1000 + 5)
+
+    expect(closeHandler).toHaveBeenCalledWith({
+      code: 1006,
+      reason: 'UDP disconnect'
     })
   })
 })


### PR DESCRIPTION
Fixes #107.

Changes proposed in this pull request:

- Add handling of disconnection on the UDP Stack.
  - When the WebSocket did close.
  - When no messages are received for more then 1 minutes and 45 seconds.

Reviewer: @Terreii
