### PR TITLE
EventTarget

### DIFF
--- a/src/actions/connectCircuit.js
+++ b/src/actions/connectCircuit.js
@@ -36,7 +36,7 @@ function connect (dispatch, circuit) {
     },
     closeHandler: null
   }
-  listeners.closeHandler = closeHandler(dispatch, listeners)
+  listeners.closeHandler = closeHandler(dispatch, circuit, listeners)
 
   circuit.addEventListener('packetReceived', listeners.simAction)
   circuit.addEventListener('close', listeners.closeHandler)
@@ -57,9 +57,10 @@ function removeEventListeners (circuit, listeners) {
 /**
  * Listens to close event. If the there is a reason, dispatch it.
  * @param {function} dispatch    Redux Store dispatch
+ * @param {EventTarget} circuit  Circuit from network/circuit.
  * @param {simAction: EventListener, closeHandler: EventListener} listeners Event listeners.
  */
-function closeHandler (dispatch, listeners) {
+function closeHandler (dispatch, circuit, listeners) {
   const disconnectMessage = 'You have been disconnected!\n\n' +
     'Please check if you have an Internet connection.\n' +
     'This problem could also be on our or the grids side.'
@@ -74,13 +75,11 @@ function closeHandler (dispatch, listeners) {
       ? reasonTexts[event.detail.reason]
       : event.detail.reason
 
-    dispatch((dispatch, getState, { circuit }) => {
-      removeEventListeners(circuit, listeners)
+    removeEventListeners(circuit, listeners)
 
-      if (event.detail.code !== 1000) {
-        // not normal circuit close
-        dispatch(userWasKicked({ reason }))
-      }
-    })
+    if (event.detail.code !== 1000) {
+      // not normal circuit close
+      dispatch(userWasKicked({ reason }))
+    }
   }
 }

--- a/src/actions/connectCircuit.js
+++ b/src/actions/connectCircuit.js
@@ -1,35 +1,65 @@
-import createCallback from './simAction'
+import simAction from './simAction'
 import { userWasKicked } from '../bundles/session'
 
 // Starts listening to packets on the circuit and dispatch a parsed action.
 export default function init () {
   return (dispatch, getState, { circuit }) => {
-    let callback = createCallback(dispatch)
-    circuit.on('packetReceived', callback)
-
-    let closeHandler = getCloseHandler(dispatch)
-    circuit.on('close', closeHandler)
+    let listeners = connect(dispatch, circuit)
 
     if (process.env.NODE_ENV !== 'production') {
       if (module.hot) {
         // Replace simAction-callback if it changes
         module.hot.accept('./simAction', () => {
-          circuit.removeListener('packetReceived', callback)
-          callback = createCallback(dispatch)
-          circuit.on('packetReceived', callback)
+          removeEventListeners(circuit, listeners)
+          listeners = connect(dispatch, circuit)
         })
 
         module.hot.accept('../bundles/session', () => {
-          circuit.removeListener('close', closeHandler)
-          closeHandler = getCloseHandler(dispatch)
-          circuit.on('close', closeHandler)
+          removeEventListeners(circuit, listeners)
+          listeners = connect(dispatch, circuit)
         })
       }
     }
   }
 }
 
-function getCloseHandler (dispatch) {
+/**
+ * Connects the event listeners to the Circuit.
+ * @param {function} dispatch    Redux Store dispatch
+ * @param {EventTarget} circuit  Circuit from network/circuit.
+ * @returns {{simAction: EventListener, closeHandler: EventListener}} Event listeners.
+ */
+function connect (dispatch, circuit) {
+  const listeners = {
+    simAction: event => {
+      dispatch(simAction(event))
+    },
+    closeHandler: null
+  }
+  listeners.closeHandler = closeHandler(dispatch, listeners)
+
+  circuit.addEventListener('packetReceived', listeners.simAction)
+  circuit.addEventListener('close', listeners.closeHandler)
+
+  return listeners
+}
+
+/**
+ * Remove all event listeners from the circuit.
+ * @param {EventTarget} circuit Circuit from network/circuit.
+ * @param {{simAction: EventListener, closeHandler: EventListener}} listeners Event listeners.
+ */
+function removeEventListeners (circuit, listeners) {
+  circuit.removeEventListener('packetReceived', listeners.simAction)
+  circuit.removeEventListener('close', listeners.closeHandler)
+}
+
+/**
+ * Listens to close event. If the there is a reason, dispatch it.
+ * @param {function} dispatch    Redux Store dispatch
+ * @param {simAction: EventListener, closeHandler: EventListener} listeners Event listeners.
+ */
+function closeHandler (dispatch, listeners) {
   const disconnectMessage = 'You have been disconnected!\n\n' +
     'Please check if you have an Internet connection.\n' +
     'This problem could also be on our or the grids side.'
@@ -40,9 +70,17 @@ function getCloseHandler (dispatch) {
   }
 
   return event => {
-    const reason = event.reason in reasonTexts
-      ? reasonTexts[event.reason]
-      : event.reason
-    dispatch(userWasKicked({ reason }))
+    const reason = event.detail.reason in reasonTexts
+      ? reasonTexts[event.detail.reason]
+      : event.detail.reason
+
+    dispatch((dispatch, getState, { circuit }) => {
+      removeEventListeners(circuit, listeners)
+
+      if (event.detail.code !== 1000) {
+        // not normal circuit close
+        dispatch(userWasKicked({ reason }))
+      }
+    })
   }
 }

--- a/src/actions/connectCircuit.test.js
+++ b/src/actions/connectCircuit.test.js
@@ -1,0 +1,103 @@
+import connectCircuit from './connectCircuit'
+
+it('should listen to packages on the Circuit in the thunk extra argument', () => {
+  const innerFn = connectCircuit()
+  const dispatch = jest.fn()
+  const getState = jest.fn(() => ({}))
+  const circuitAddEventListener = jest.fn()
+
+  innerFn(dispatch, getState, {
+    circuit: {
+      addEventListener: circuitAddEventListener
+    }
+  })
+
+  expect(dispatch).not.toBeCalled()
+  expect(getState).not.toBeCalled()
+  expect(circuitAddEventListener).toBeCalledTimes(2)
+  expect(circuitAddEventListener)
+    .toHaveBeenNthCalledWith(1, 'packetReceived', expect.any(Function))
+  expect(circuitAddEventListener).toHaveBeenNthCalledWith(2, 'close', expect.any(Function))
+})
+
+it('should close all event-listeners on the close event', () => {
+  const innerFn = connectCircuit()
+  const dispatch = jest.fn()
+  const getState = jest.fn(() => ({}))
+  const eventListeners = new Map()
+  const circuitRemoveEventListener = jest.fn()
+  const circuit = {
+    addEventListener (eventName, listener) {
+      eventListeners.set(eventName, listener)
+    },
+    removeEventListener: circuitRemoveEventListener
+  }
+
+  innerFn(dispatch, getState, { circuit })
+
+  const closeListener = eventListeners.get('close')
+  expect(typeof closeListener).toBe('function')
+
+  closeListener(new window.CustomEvent('close', {
+    detail: {
+      code: 1006,
+      reason: 'Max reconnection tries'
+    }
+  }))
+
+  expect(dispatch).toHaveBeenLastCalledWith(expect.any(Function))
+  const cb = dispatch.mock.calls[0][0]
+  cb(dispatch, getState, { circuit })
+
+  expect(dispatch).toHaveBeenLastCalledWith({
+    type: 'session/userWasKicked',
+    payload: {
+      reason: 'You have been disconnected!\n\n' +
+        'Please check if you have an Internet connection.\n' +
+        'This problem could also be on our or the grids side.'
+    }
+  })
+  expect(getState).not.toHaveBeenCalled()
+  expect(circuitRemoveEventListener)
+    .toHaveBeenNthCalledWith(1, 'packetReceived', eventListeners.get('packetReceived'))
+  expect(circuitRemoveEventListener)
+    .toHaveBeenNthCalledWith(2, 'close', eventListeners.get('close'))
+})
+
+it('should not dispatch an kick event if the circuit did close with 1000', () => {
+  const innerFn = connectCircuit()
+  const dispatch = jest.fn()
+  const getState = jest.fn(() => ({}))
+  const eventListeners = new Map()
+  const circuitRemoveEventListener = jest.fn()
+  const circuit = {
+    addEventListener (eventName, listener) {
+      eventListeners.set(eventName, listener)
+    },
+    removeEventListener: circuitRemoveEventListener
+  }
+
+  innerFn(dispatch, getState, { circuit })
+
+  const closeListener = eventListeners.get('close')
+  expect(typeof closeListener).toBe('function')
+
+  closeListener(new window.CustomEvent('close', {
+    detail: {
+      code: 1000,
+      reason: 'session end'
+    }
+  }))
+
+  expect(dispatch).toBeCalledTimes(1)
+  expect(dispatch).toHaveBeenLastCalledWith(expect.any(Function))
+  const cb = dispatch.mock.calls[0][0]
+  cb(dispatch, getState, { circuit })
+
+  expect(dispatch).toBeCalledTimes(1)
+  expect(getState).not.toHaveBeenCalled()
+  expect(circuitRemoveEventListener)
+    .toHaveBeenNthCalledWith(1, 'packetReceived', eventListeners.get('packetReceived'))
+  expect(circuitRemoveEventListener)
+    .toHaveBeenNthCalledWith(2, 'close', eventListeners.get('close'))
+})

--- a/src/actions/connectCircuit.test.js
+++ b/src/actions/connectCircuit.test.js
@@ -45,10 +45,6 @@ it('should close all event-listeners on the close event', () => {
     }
   }))
 
-  expect(dispatch).toHaveBeenLastCalledWith(expect.any(Function))
-  const cb = dispatch.mock.calls[0][0]
-  cb(dispatch, getState, { circuit })
-
   expect(dispatch).toHaveBeenLastCalledWith({
     type: 'session/userWasKicked',
     payload: {
@@ -89,12 +85,7 @@ it('should not dispatch an kick event if the circuit did close with 1000', () =>
     }
   }))
 
-  expect(dispatch).toBeCalledTimes(1)
-  expect(dispatch).toHaveBeenLastCalledWith(expect.any(Function))
-  const cb = dispatch.mock.calls[0][0]
-  cb(dispatch, getState, { circuit })
-
-  expect(dispatch).toBeCalledTimes(1)
+  expect(dispatch).toBeCalledTimes(0)
   expect(getState).not.toHaveBeenCalled()
   expect(circuitRemoveEventListener)
     .toHaveBeenNthCalledWith(1, 'packetReceived', eventListeners.get('packetReceived'))

--- a/src/actions/simAction.js
+++ b/src/actions/simAction.js
@@ -5,8 +5,13 @@ import { changeRights } from '../bundles/friends'
 import { selectAgentId, selectSessionId } from '../bundles/session'
 import { doHandleFriendOnlineStateChange } from './friendsActions'
 
-// Gets all messages from the SIM and filters them, and if needed: calls their own actions.
-function simActionFilter (msg) {
+/**
+ * Gets all messages from the SIM and filters them, and if needed: calls their own actions.
+ * @param {CustomEvent} event Event from circuit with the Package data in `detail`.
+ */
+export default function simActionFilter (event) {
+  const msg = event.detail
+
   switch (msg.name) {
     case 'ChatFromSimulator':
       return receiveChatFromSimulator(msg)
@@ -37,7 +42,9 @@ function simActionFilter (msg) {
       if (process.env.NODE_ENV !== 'production' && window.debugDispatchAllMsg) {
         return msg
       }
-      break
+      // Don't dispatch an action.
+      // This is an empty thunk action. It will be called and does then nothing.
+      return () => {}
   }
 }
 
@@ -79,14 +86,5 @@ function sendRegionHandshakeReply (RegionHandshake) {
       regionID,
       flags
     })
-  }
-}
-
-export default function createCallback (dispatch) {
-  return msg => {
-    const action = simActionFilter(msg)
-    if (action != null) { // If the packet is parsed, an action will be dispatched.
-      dispatch(action)
-    }
   }
 }

--- a/src/actions/viewerAccount.test.js
+++ b/src/actions/viewerAccount.test.js
@@ -407,7 +407,7 @@ describe('grids', () => {
       isLLSDLogin: false
     })
 
-    await new Promise(resolve => setTimeout(resolve, 5))
+    await new Promise(resolve => setTimeout(resolve, 10))
 
     expect(getDiff('A')).toEqual({
       account: {
@@ -455,7 +455,7 @@ describe('grids', () => {
       isLLSDLogin: false
     })
 
-    await new Promise(resolve => setTimeout(resolve, 5))
+    await new Promise(resolve => setTimeout(resolve, 10))
 
     expect(getDiff('A')).toEqual({
       account: {

--- a/src/network/circuit.js
+++ b/src/network/circuit.js
@@ -6,13 +6,12 @@
  * and the event 'packetReceived'
  */
 
-import events from 'events'
 import Queue from 'double-ended-queue'
 
 import { parseBody, createBody } from './networkMessages'
 import { getValueOf, mapBlockOf } from './msgGetters'
 
-export default class Circuit extends events.EventEmitter {
+export default class Circuit extends window.EventTarget {
   /**
    * sequenceNumber is the id of a packet.
    * It will be increased for every packed.
@@ -121,21 +120,23 @@ export default class Circuit extends events.EventEmitter {
     }
 
     if (event.code === 1008) {
-      this.emit('close', {
-        code: event.code,
-        reason: event.reason
-      })
-      this.removeAllListeners()
+      this.dispatchEvent(new window.CustomEvent('close', {
+        detail: {
+          code: event.code,
+          reason: event.reason
+        }
+      }))
       clearInterval(this.acksProcessInterval)
       return
     }
 
     if (this.reconnectCount > 10) {
-      this.emit('close', {
-        code: 1006,
-        reason: 'Max reconnection tries'
-      })
-      this.removeAllListeners()
+      this.dispatchEvent(new window.CustomEvent('close', {
+        detail: {
+          code: 1006,
+          reason: 'Max reconnection tries'
+        }
+      }))
       clearInterval(this.acksProcessInterval)
       return
     }
@@ -149,7 +150,6 @@ export default class Circuit extends events.EventEmitter {
 
   close () {
     this.websocket.close(1000, 'session end')
-    this.removeAllListeners()
     clearInterval(this.acksProcessInterval)
   }
 
@@ -217,8 +217,12 @@ export default class Circuit extends events.EventEmitter {
       this._resolveAcks(mapBlockOf(parsedBody, 'Packets', getValue => getValue('ID')))
     } else {
       // For every message that is not a circuit control message
-      this.emit(parsedBody.name, parsedBody)
-      this.emit('packetReceived', parsedBody)
+      this.dispatchEvent(new window.CustomEvent(parsedBody.name, {
+        detail: parsedBody
+      }))
+      this.dispatchEvent(new window.CustomEvent('packetReceived', {
+        detail: parsedBody
+      }))
     }
   }
 
@@ -339,10 +343,12 @@ export default class Circuit extends events.EventEmitter {
       this.lastReceivedCount += 1
 
       if (this.lastReceivedCount > 1050) {
-        this.emit('close', {
-          code: 1006,
-          reason: 'UDP disconnect'
-        })
+        this.dispatchEvent(new window.CustomEvent('close', {
+          detail: {
+            code: 1006,
+            reason: 'UDP disconnect'
+          }
+        }))
         this.close()
         return
       }

--- a/src/network/circuit.js
+++ b/src/network/circuit.js
@@ -116,6 +116,13 @@ export default class Circuit extends window.EventTarget {
 
     if (event.code === 1000) {
       // Normal session end
+      this.dispatchEvent(new window.CustomEvent('close', {
+        detail: {
+          code: event.code,
+          reason: event.reason
+        }
+      }))
+      clearInterval(this.acksProcessInterval)
       return
     }
 

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from 'events'
-
 import { diff as getObjDiff } from 'deep-object-diff'
 import PouchDB from 'pouchdb-browser'
 import memoryAdapter from 'pouchdb-adapter-memory'
@@ -480,6 +478,6 @@ async function setStateToConnectedToGrid (
   store.dispatch(connectCircuit())
 }
 
-export class CircuitMock extends EventEmitter {
+export class CircuitMock extends window.EventTarget {
   send = jest.fn(() => Promise.resolve())
 }


### PR DESCRIPTION
To use Browser capabilities instead of node.js.

Changes proposed in this pull request:

- Use `EventTarget` for the parent class of Circuit.
- Use `CustomEvent` for Circuit events.

Reviewer: @Terreii
